### PR TITLE
E2E test fixes, chat sync guards, geocoding & i18n improvements

### DIFF
--- a/.claude/agents/e2e-test-investigator.md
+++ b/.claude/agents/e2e-test-investigator.md
@@ -1,0 +1,130 @@
+---
+name: e2e-test-investigator
+description: Investigate a specific failing Playwright E2E spec — reads screenshots, queries OpenObserve client+backend logs via debug.py, traces the spec code, reads frontend components, identifies root cause, and proposes or applies a fix. Use for any individual spec failure that needs deep investigation beyond what test-failure-triager provides.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+maxTurns: 40
+---
+
+You are an E2E test failure investigator for the OpenMates project. Given a failing spec name and failure context, you deeply investigate the root cause by correlating screenshots, OpenObserve logs, spec code, and frontend components. Unlike the test-failure-triager (which only clusters and ranks), you perform a full investigation and either propose or apply a fix.
+
+## Input
+
+The parent agent passes you:
+- The failing spec file name (e.g. `signup-flow-polar.spec.ts`)
+- The failure step, error message, and any screenshots observed
+- Whether to investigate only (report back) or also apply a fix
+
+## Investigation Protocol
+
+### Step 1: Read the failure report and screenshots (parallel)
+
+```bash
+# Read the failure report
+cat test-results/reports/failed/<spec-name>.md
+
+# List available screenshots for this spec
+ls test-results/screenshots/current/<spec-folder>/
+```
+
+**Always read screenshots** — error messages frequently do NOT reflect what's actually on screen. The screenshot is the ground truth. Read both the `test-failed-*.png` screenshots AND the last successful step screenshot to understand what state the app was in before failure.
+
+### Step 2: Read the spec code
+
+Read the full spec file in `frontend/apps/web_app/tests/<spec-name>.spec.ts`. Identify:
+- What step the test was on when it failed
+- What the test expected to see vs. what was actually on screen
+- The test flow leading up to the failure (what state was built up)
+- Any shared helpers used (commonly from `signup-flow-helpers.ts`)
+
+### Step 3: Query OpenObserve for correlated logs
+
+E2E tests send client console logs to OpenObserve tagged with a run ID. Query both client and backend logs around the failure time:
+
+```bash
+# Client console logs for the test run (if run_id is known)
+docker exec api python /app/backend/scripts/debug.py logs --o2 --query-json \
+  '{"stream":"client_console","filters":[{"field":"debugging_id","op":"like","value":"%<spec-name-fragment>%"}],"since_minutes":120,"limit":50}'
+
+# Backend errors around the test time
+docker exec api python /app/backend/scripts/debug.py logs --o2 --query-json \
+  '{"stream":"default","filters":[{"field":"level","op":"in","value":["ERROR","WARNING"]},{"field":"message","op":"like","value":"%<relevant-keyword>%"}],"since_minutes":120,"limit":30}'
+
+# Auth/session errors (common in signup tests)
+docker exec api python /app/backend/scripts/debug.py logs --o2 --query-json \
+  '{"stream":"default","filters":[{"field":"message","op":"like","value":"%expired%"}],"since_minutes":120,"limit":20}'
+
+# Trace errors on relevant routes
+docker exec api python /app/backend/scripts/debug.py trace errors --last 2h --route <relevant-route>
+```
+
+Adapt queries based on the failure type — e.g., for email verification failures, search for "verification code"; for payment failures, search for "checkout" or "polar" or "stripe".
+
+### Step 4: Read the frontend component code
+
+Based on the failure step, identify and read the relevant Svelte component(s):
+- Signup steps: `frontend/packages/ui/src/components/signup/steps/`
+- Payment: `frontend/packages/ui/src/components/signup/steps/payment/`
+- Auth services: `frontend/packages/ui/src/services/`
+- Stores: `frontend/packages/ui/src/stores/`
+
+### Step 5: Check for regressions
+
+```bash
+# Recent commits that might have caused the failure
+git log -10 --oneline
+
+# Changes to the failing component
+git log -5 --oneline -- <component-file>
+
+# Diff between last known good commit and current
+git diff <last-good-sha>..HEAD -- <relevant-files>
+```
+
+### Step 6: Identify root cause and fix
+
+Synthesize all evidence into a root cause. Common E2E failure patterns:
+
+| Pattern | Symptom | Typical Cause |
+|---------|---------|---------------|
+| Element not found after working step | Screenshot shows different page | Session loss, redirect, race condition |
+| Timeout waiting for element | Screenshot shows loading/spinner | Backend slow, missing data, broken async |
+| Wrong text/content visible | Screenshot confirms mismatch | Regression in component rendering |
+| Email/code verification fails | "No verification code" error | Cache miss race, email collision, Celery delay |
+| Payment iframe not loading | Empty checkout area | Provider config, CSP, iframe nesting issue |
+| Consent overlay blocking clicks | Element visible but not clickable | Pointer-events overlay, z-index issue |
+| Test passes alone, fails in batch | Intermittent failure | Shared state (email collision, DB conflict) |
+
+## Rules
+
+- **Screenshots are truth.** Error messages in the test report often describe a downstream symptom, not the root cause. Always check what the screenshot actually shows.
+- **Never run tests locally.** Use `python3 scripts/run_tests.py --spec <name>.spec.ts` to dispatch to GitHub Actions CI.
+- **Never run vitest or Playwright directly.** Always dispatch via `run_tests.py`.
+- **Query OpenObserve systematically.** Don't guess — check the logs. The E2E debug log pipeline tags client console logs with the test run ID.
+- **Check for batch interactions.** If the spec passes when run alone but fails in daily runs, the issue is likely shared state (email addresses, test accounts, DB records).
+- **2 tries max per investigation angle.** If you can't find the cause after two attempts with the same approach, try a different angle.
+- **Keep report under 500 words.** If also applying a fix, explain the fix concisely.
+
+## Output Format
+
+If investigation only (no fix):
+
+```
+## Root Cause Analysis
+
+**Spec:** <spec-name>.spec.ts
+**Failure step:** <step number and description>
+**Root cause:** <one paragraph>
+**Category:** regression | race_condition | test_bug | infrastructure | shared_state | config
+**Confidence:** high | medium | low
+
+**Evidence:**
+- <bullet points of key evidence>
+
+**Suspect files:**
+- <file:line — reason>
+
+**Suggested fix:** <specific code change needed>
+```
+
+If also applying a fix, apply it and report what was changed and why.

--- a/.claude/rules/debugging.md
+++ b/.claude/rules/debugging.md
@@ -35,6 +35,7 @@ All commands support `--production` and `--json` flags.
 - **`issue-forensics`** — for any user-reported issue ID. Runs `debug.py issue --timeline`, correlates browser↔backend events, git-blames suspects, returns root-cause hypothesis + suspect files. Use via `/debug-issue` skill or spawn directly.
 - **`encryption-flow-tracer`** — for any symptom involving "content decryption failed", key mismatch, cross-device sync bugs, or the `multi-tab-encryption` / `multi-session-encryption` specs. Pre-loaded with the 5 encryption architecture docs. Spawn alongside `issue-forensics` when symptoms point at E2EE.
 - **`test-failure-triager`** — for any failing Playwright/vitest/pytest run. Reads all failure reports and returns ranked root-cause groups. Use via `/fix-tests` or `/fix-next-test`.
+- **`e2e-test-investigator`** — for deep investigation of a **specific** failing E2E spec. Reads screenshots (ground truth — error messages often lie), queries OpenObserve client+backend logs, traces spec code through frontend components, identifies root cause, and proposes or applies a fix. Use when `test-failure-triager` has identified the failing spec but you need to understand *why* it fails. Spawn one per failing spec for parallel investigation.
 
 Only fall back to running these commands yourself if the subagents are unavailable:
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -27,6 +27,44 @@ The daily cron job (`run_tests.py --daily`) runs every night and saves results l
 
 **Do NOT** re-download results from GitHub Actions or re-run tests just to see what failed — the results are already local.
 
+## Investigating a Failing E2E Spec
+
+When a specific spec fails and needs deep investigation, use the **`e2e-test-investigator`** subagent. Spawn one per failing spec for parallel investigation.
+
+**Key principle: screenshots are ground truth.** Error messages in failure reports often describe downstream symptoms, not root causes. Always read `test-results/screenshots/current/<spec-folder>/test-failed-*.png` AND the last successful step screenshot.
+
+### Manual investigation checklist (if not using the subagent)
+
+1. **Read the failure report:** `test-results/reports/failed/<spec-name>.md`
+2. **Read screenshots:** `test-results/screenshots/current/<spec-folder>/` — compare what the test expected vs. what's actually on screen
+3. **Query OpenObserve for client console logs from the test run:**
+   ```bash
+   docker exec api python /app/backend/scripts/debug.py logs --o2 --query-json \
+     '{"stream":"client_console","filters":[{"field":"debugging_id","op":"like","value":"%<spec-name>%"}],"since_minutes":120,"limit":50}'
+   ```
+4. **Query backend logs for related errors:**
+   ```bash
+   docker exec api python /app/backend/scripts/debug.py logs --o2 --query-json \
+     '{"stream":"default","filters":[{"field":"level","op":"in","value":["ERROR","WARNING"]},{"field":"message","op":"like","value":"%<keyword>%"}],"since_minutes":120,"limit":30}'
+   ```
+5. **Read the spec code** to understand what step failed and what was expected
+6. **Read the frontend component** involved in the failing step
+7. **Check for regressions:** `git log -5 --oneline -- <component-file>`
+
+### E2E Debug Log Pipeline
+
+All Playwright specs use `getE2EDebugUrl()` which injects `#e2e-debug={runId}-{specName}&e2e-token={hmac}` into the URL. The frontend detects this at page load and starts forwarding all console logs to OpenObserve via `POST /e2e/client-logs`, tagged with the run ID. This works pre-login, so the full test flow (including login/signup) is captured.
+
+### Common E2E failure patterns
+
+| Pattern | Symptom | Typical Cause |
+|---------|---------|---------------|
+| Element not found, screenshot shows different page | Session lost, user redirected | Auth token expired, refresh token revoked |
+| "No verification code" error | Email code rejected | Cache miss race (Celery hasn't written code yet) or email collision between batched tests |
+| Timeout on iframe/overlay | Spinner or empty area visible | Provider iframe failed to load, CSP block, nesting issue |
+| Element visible but click times out | Overlay blocking pointer events | Consent/modal overlay with `pointer-events: all` on top |
+| Spec passes alone, fails in batch | Intermittent/flaky | Shared state: email collision, test account reuse, DB conflict |
+
 ## Additional Test Rules
 
 - **NEVER use CSS class selectors in tests.** All element targeting MUST use `data-testid` attributes with `page.getByTestId('name')`. CSS classes are styling concerns and break when CSS changes.

--- a/backend/apps/ai/tasks/focus_mode_auto_confirm_task.py
+++ b/backend/apps/ai/tasks/focus_mode_auto_confirm_task.py
@@ -233,11 +233,11 @@ async def _async_focus_mode_auto_confirm(
             "is_incognito": is_incognito,
             "mate_id": mate_id,
             "active_focus_id": focus_id,  # Focus mode is NOW active for this continuation
-            # Signal that this is a continuation after focus mode activation
-            # The task should NOT re-persist the user message (it's already persisted)
+            # Signal that this is a continuation after focus mode activation.
+            # The task should NOT re-persist the user message (it's already persisted).
+            # This continuation creates a SEPARATE assistant message (new task_id = new message_id).
+            # The client renders both messages but visually merges them into one bubble.
             "is_focus_mode_continuation": True,
-            # Continuation creates its own assistant message (new task_id = new message_id).
-            # Client merges focus activation + continuation into one bubble for display.
         }
         
         task = process_ai_skill_ask_task.apply_async(

--- a/backend/apps/ai/tasks/stream_consumer.py
+++ b/backend/apps/ai/tasks/stream_consumer.py
@@ -3783,8 +3783,9 @@ async def _consume_main_processing_stream(
     # Handle the case where we're awaiting focus mode confirmation (deferred activation).
     # Unlike app_settings, the focus mode case has embed content (the focus mode activation
     # embed reference) that we need to finalize so the client can persist the message.
-    # The continuation task (auto-confirm or rejection) will reuse the same message_id
-    # (via continuation_message_id) and append the LLM response to this message.
+    # The continuation task (auto-confirm or rejection) creates a SEPARATE assistant message
+    # with its own task_id. The client renders both messages but visually merges them
+    # into one bubble for display continuity.
     if awaiting_focus_mode_confirmation:
         logger.info(
             f"{log_prefix} Task completing with embed content only — awaiting focus mode confirmation. "
@@ -3794,7 +3795,6 @@ async def _consume_main_processing_stream(
         # Publish a final chunk with the embed content so the client:
         # 1. Transitions the message from 'streaming' to 'synced'
         # 2. Persists it to IndexedDB (embed survives page reload)
-        # The continuation task will target the same message_id and append the LLM response.
         if cache_service and aggregated_response:
             focus_final_payload = _create_redis_payload(
                 task_id, request_data, aggregated_response, stream_chunk_count + 1,
@@ -3804,6 +3804,38 @@ async def _consume_main_processing_stream(
                 cache_service, redis_channel_name, focus_final_payload, log_prefix,
                 f"Published focus-mode final marker (seq: {stream_chunk_count + 1}, content: {len(aggregated_response)} chars) to '{redis_channel_name}'"
             )
+
+        # Increment messages_v and save to AI cache — this IS a real persisted assistant
+        # message (the focus activation embed). Without this, messages_v drifts: the
+        # continuation task increments for its own message, but this one was skipped,
+        # causing the health check to report "messages_v (N) != actual count (N+1)".
+        if not request_data.is_external and directus_service and cache_service and encryption_service and user_vault_key_id:
+            category = preprocessing_result.category or "general_knowledge"
+            timestamp = int(time.time())
+            try:
+                await _update_chat_metadata(
+                    request_data=request_data,
+                    category=category,
+                    timestamp=timestamp,
+                    content_markdown=aggregated_response,
+                    content_tiptap=aggregated_response,
+                    directus_service=directus_service,
+                    cache_service=cache_service,
+                    encryption_service=encryption_service,
+                    user_vault_key_id=user_vault_key_id,
+                    task_id=task_id,
+                    log_prefix=log_prefix,
+                    model_name=stream_model_name
+                )
+                logger.info(
+                    f"{log_prefix} Focus mode activation message saved to AI cache and messages_v incremented."
+                )
+            except Exception as e_save:
+                logger.error(
+                    f"{log_prefix} CRITICAL: Failed to save focus mode activation message: {e_save}",
+                    exc_info=True
+                )
+
         return aggregated_response, False, False, [], debug_metadata
     
     # IMPROVED LOGGING: metadata-only stream completion details.

--- a/backend/apps/ai/testing/fixtures/chat_flow_capital.json
+++ b/backend/apps/ai/testing/fixtures/chat_flow_capital.json
@@ -1,0 +1,40 @@
+{
+  "fixture_id": "chat_flow_capital",
+  "recorded_at": "2026-04-13T13:00:00Z",
+  "speed_profile": "instant",
+  "user_message_snippet": "Capital of Germany?",
+  "preprocessing": {
+    "can_proceed": true,
+    "category": "general_knowledge",
+    "title": "Capital of Germany",
+    "icon_names": ["globe"],
+    "selected_model_id": "anthropic/claude-sonnet-4-20250514",
+    "selected_model_name": "Claude Sonnet",
+    "mate_id": "default",
+    "chat_summary": "User asked about the capital of Germany",
+    "chat_tags": ["geography", "general-knowledge"],
+    "relevant_app_skills": [],
+    "llm_response_temp": 0.7,
+    "complexity": "simple",
+    "steps": [
+      {"step": "title_generated", "data": {"title": "Capital of Germany"}},
+      {"step": "mate_selected", "data": {"mate_id": "default"}},
+      {"step": "model_selected", "data": {"model_name": "Claude Sonnet", "provider_name": "Anthropic"}}
+    ]
+  },
+  "typing_started": {
+    "category": "general_knowledge",
+    "model_name": "Claude Sonnet",
+    "provider_name": "Anthropic",
+    "server_region": "EU"
+  },
+  "response": "The capital of Germany is **Berlin**. It has been the capital since German reunification in 1990. Berlin is also the largest city in Germany, with a population of approximately 3.7 million people.",
+  "skill_executions": [],
+  "thinking_content": null,
+  "usage": {
+    "prompt_tokens": 45,
+    "completion_tokens": 40,
+    "total_credits": 3,
+    "model_name": "Claude Sonnet"
+  }
+}

--- a/backend/apps/home/skills/search_skill.py
+++ b/backend/apps/home/skills/search_skill.py
@@ -209,14 +209,13 @@ class SearchSkill(BaseSkill):
         """
         Attach latitude/longitude to each listing by geocoding its address.
 
-        Uses geocode_address() from geo_utils which tries a local city table
-        first (zero cost), then falls back to Nominatim (OSM). Listings without
-        a resolvable address are left without coordinates — the frontend will
-        simply hide the map for those.
+        Uses geocode_address() from geo_utils which tries Nominatim first for
+        address-level precision, then falls back to the local city table. Listings
+        without a resolvable address are left without coordinates — the frontend
+        will simply hide the map for those.
 
-        Geocoding is done sequentially to respect Nominatim's 1 req/s rate limit.
-        The local city table handles the common case (city-level addresses) with
-        zero network calls, so most listings resolve instantly.
+        Geocoding is done sequentially; _nominatim_query auto-throttles to
+        respect Nominatim's 1 req/s rate limit.
 
         Args:
             listings: Mutable list of listing dicts — latitude/longitude keys

--- a/backend/scripts/debug_chat.py
+++ b/backend/scripts/debug_chat.py
@@ -2019,7 +2019,38 @@ async def main():
                 )
             
             print(output)
-            
+
+            # ---- AUTO CROSS-CHECK: production server ----
+            # After local inspection, also check if the chat exists on the
+            # production server. This prevents confusion when investigating
+            # issues reported from production while running debug.py on dev.
+            try:
+                prod_response = await fetch_chat_from_production_api(
+                    args.chat_id, use_dev=False
+                )
+                prod_data = prod_response.get("data", {}) if prod_response else {}
+                prod_chat = prod_data.get("chat_metadata")
+                prod_found = prod_chat and prod_chat.get("chat_id")
+
+                print("\n" + "─" * 50)
+                print("🌐 PRODUCTION CROSS-CHECK")
+                if prod_found:
+                    prod_msgs = prod_data.get("messages", {})
+                    prod_embeds = prod_data.get("embeds", {})
+                    prod_msg_count = prod_msgs.get("total", len(prod_msgs.get("items", [])))
+                    prod_embed_count = prod_embeds.get("total", len(prod_embeds.get("items", [])))
+                    prod_msgs_v = prod_chat.get("messages_v", "?")
+                    print(f"  🟢 FOUND on production  messages={prod_msg_count}  "
+                          f"embeds={prod_embed_count}  messages_v={prod_msgs_v}")
+                else:
+                    print("  🔴 NOT FOUND on production")
+                print("─" * 50)
+            except (Exception, SystemExit) as prod_err:
+                print("\n" + "─" * 50)
+                print("🌐 PRODUCTION CROSS-CHECK")
+                print(f"  ⚠ Could not check production: {prod_err}")
+                print("─" * 50)
+
         except Exception as e:
             script_logger.error(f"Error during inspection: {e}", exc_info=True)
             raise

--- a/backend/scripts/debug_embed.py
+++ b/backend/scripts/debug_embed.py
@@ -636,11 +636,11 @@ def format_output_text(
     # ===================== EMBED DATA =====================
     lines.append("")
     lines.append("-" * 100)
-    lines.append("EMBED DATA (from Directus)")
+    lines.append("EMBED DATA (from local dev Directus)")
     lines.append("-" * 100)
 
     if not embed:
-        lines.append("❌ Embed NOT FOUND in Directus")
+        lines.append("❌ Embed NOT FOUND in local dev Directus")
     else:
         # Core metadata
         lines.append(f"  Directus ID:                 {embed.get('id', 'N/A')}")
@@ -730,7 +730,7 @@ def format_output_text(
     # ===================== EMBED KEYS =====================
     lines.append("")
     lines.append("-" * 100)
-    lines.append(f"EMBED KEYS (from Directus) - Total: {len(embed_keys)}")
+    lines.append(f"EMBED KEYS (from local dev Directus) - Total: {len(embed_keys)}")
     lines.append("-" * 100)
 
     if not embed_keys:
@@ -845,7 +845,7 @@ def format_output_text(
     if child_embeds:
         lines.append("")
         lines.append("-" * 100)
-        lines.append(f"CHILD EMBEDS (from Directus) - Total: {len(child_embeds)}")
+        lines.append(f"CHILD EMBEDS (from local dev Directus) - Total: {len(child_embeds)}")
         lines.append("-" * 100)
 
         display_children = child_embeds[:MAX_CHILD_EMBEDS_DISPLAY]
@@ -1444,6 +1444,35 @@ async def main():
                 )
 
             print(output)
+
+            # ---- AUTO CROSS-CHECK: production server ----
+            # After local inspection, also check if the embed exists on the
+            # production server. This prevents confusion when investigating
+            # issues reported from production while running debug.py on dev.
+            try:
+                prod_response = await fetch_embed_from_production_api(
+                    args.embed_id, use_dev=False
+                )
+                prod_mapped = map_production_embed_response(prod_response) if prod_response else {}
+                prod_embed = prod_mapped.get("embed")
+                prod_found = prod_embed and prod_embed.get("embed_id")
+
+                print("\n" + "─" * 50)
+                print("🌐 PRODUCTION CROSS-CHECK")
+                if prod_found:
+                    prod_status = prod_embed.get("status", "?")
+                    prod_keys = prod_mapped.get("embed_keys", [])
+                    prod_children = prod_mapped.get("child_embeds", [])
+                    print(f"  🟢 FOUND on production  status={prod_status}  "
+                          f"keys={len(prod_keys)}  children={len(prod_children)}")
+                else:
+                    print("  🔴 NOT FOUND on production")
+                print("─" * 50)
+            except (Exception, SystemExit) as prod_err:
+                print("\n" + "─" * 50)
+                print("🌐 PRODUCTION CROSS-CHECK")
+                print(f"  ⚠ Could not check production: {prod_err}")
+                print("─" * 50)
 
         except Exception as e:
             script_logger.error(f"Error during inspection: {e}", exc_info=True)

--- a/backend/scripts/debug_issue.py
+++ b/backend/scripts/debug_issue.py
@@ -2579,7 +2579,11 @@ async def main():
                 if args.timeline:
                     # --timeline: query OpenObserve directly, no S3 needed
                     if not issue:
-                        script_logger.error(f"Issue not found: {args.issue_id}")
+                        script_logger.error(
+                            f"Issue not found: {args.issue_id}\n"
+                            "    ℹ️  This issue may have been submitted on production.\n"
+                            "    Try: debug.py issue <id> --production"
+                        )
                         sys.exit(1)
                     print(
                         f"{_C_DIM}Querying OpenObserve timeline "

--- a/backend/shared/python_utils/geo_utils.py
+++ b/backend/shared/python_utils/geo_utils.py
@@ -5,21 +5,27 @@
 # Used by event providers (Meetup, Luma) to attach lat/lon to venue data so
 # the frontend can render an interactive map in EventEmbedFullscreen.
 #
-# Geocoding strategy (cheapest-first):
-#   1. CITY_COORDS local table — zero network cost, covers ~60 major cities.
-#   2. Nominatim (OpenStreetMap) free geocoding API — for full street addresses
-#      that include a city we don't have in CITY_COORDS.
-#   3. Returns None on failure — callers must handle gracefully (no map shown).
+# Geocoding strategy (precision-first when address available):
+#   1. Address provided → Nominatim (OpenStreetMap) for street-level precision.
+#   2. No address / Nominatim fails → CITY_COORDS local table (zero network cost).
+#   3. City not in local table → Nominatim with city name only.
+#   4. Returns None on failure — callers must handle gracefully (no map shown).
 #
 # See docs/architecture/embeds.md
 
+import asyncio
 import logging
+import time
 import urllib.parse
 from typing import Optional, Tuple
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# Nominatim rate-limit: 1 request per second. Track last request time to
+# throttle automatically when geocoding multiple addresses in sequence.
+_last_nominatim_request: float = 0.0
 
 # ---------------------------------------------------------------------------
 # Local city lookup table
@@ -130,22 +136,18 @@ async def geocode_address(
     Resolve a street address (or city) to (lat, lon).
 
     Strategy:
-    1. If city is provided, try the local CITY_COORDS table first (zero cost).
-    2. If address is provided, query Nominatim with the full address string.
-    3. If that fails, fall back to querying Nominatim with just the city name.
+    1. If address is provided, query Nominatim for address-level precision.
+    2. If no address or Nominatim fails, try the local CITY_COORDS table (zero cost).
+    3. If city isn't in the local table, query Nominatim with just the city name.
     4. Returns None on any failure — callers should degrade gracefully.
 
     This function is I/O-bound so it must be awaited. Never call it in a
     tight loop — Nominatim enforces a 1 req/s rate limit per IP.
     """
-    # Step 1: fast local city lookup
-    if city:
-        coords = lookup_city(city)
-        if coords:
-            logger.debug("geo_utils: local city hit for %r → %s", city, coords)
-            return coords
-
-    # Step 2: full address via Nominatim
+    # Step 1: if a street address is provided, try Nominatim for address-level
+    # precision first. Only fall back to city-level coords when no address is
+    # given or Nominatim fails — otherwise the map always shows the city center
+    # instead of the actual listing/venue location.
     if address:
         query_parts = [address]
         if city:
@@ -157,7 +159,14 @@ async def geocode_address(
         if coords:
             return coords
 
-    # Step 3: city-only Nominatim fallback (if city lookup above failed)
+    # Step 2: fast local city lookup (no address, or Nominatim failed)
+    if city:
+        coords = lookup_city(city)
+        if coords:
+            logger.debug("geo_utils: local city hit for %r → %s", city, coords)
+            return coords
+
+    # Step 3: city-only Nominatim fallback (city not in local table)
     if city:
         city_query = city
         if country:
@@ -178,7 +187,14 @@ async def _nominatim_query(query: str) -> Optional[Tuple[float, float]]:
     """
     Query Nominatim (OpenStreetMap) geocoding API.
     Returns (lat, lon) of the first result, or None on failure.
+    Automatically throttles to respect Nominatim's 1 req/s rate limit.
     """
+    global _last_nominatim_request
+    elapsed = time.monotonic() - _last_nominatim_request
+    if elapsed < 1.0:
+        await asyncio.sleep(1.0 - elapsed)
+    _last_nominatim_request = time.monotonic()
+
     params = {
         "q": query,
         "format": "json",

--- a/frontend/apps/web_app/tests/chat-flow.spec.ts
+++ b/frontend/apps/web_app/tests/chat-flow.spec.ts
@@ -891,19 +891,44 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 	const phase7LogStart = consoleLogs.length;
 	await performLogin(page, logChatCheckpoint, takeStepScreenshot, '08');
 
-	// Navigate directly to the test chat.
-	// After login the app is on `/` (home). Setting the hash via page.goto()
-	// triggers the deep-link handler in +page.svelte, but the activeChatStore
-	// may already hold the chat ID from a previous phase, causing it to skip
-	// re-loading. A full page reload ensures a clean app startup with the hash.
+	// Wait for phased sync to complete before navigating to the test chat.
+	// After a fresh login, phased sync re-downloads all chat data via WebSocket.
+	// The deep-link handler in +page.svelte waits for phasedSyncComplete before
+	// loading a user chat from IndexedDB. If we navigate too early (before sync),
+	// the chat isn't in IDB yet and the deep-link handler either gives up or
+	// gets blocked by canAutoNavigate() after Phase 1a loads a different chat.
+	logChatCheckpoint('Waiting for phased sync to complete after re-login...');
+	const syncCompleted = await page.waitForEvent('console', {
+		predicate: (msg: any) =>
+			msg.text().includes('Phase 1 complete') ||
+			msg.text().includes('phasedSyncComplete') ||
+			msg.text().includes('Phase 1a: decrypted'),
+		timeout: 30000
+	}).then(() => true).catch(() => false);
+	logChatCheckpoint(`Phased sync signal detected: ${syncCompleted}`);
+
+	// Navigate to the test chat via hash change (no reload — preserves sync state)
 	logChatCheckpoint(`Navigating to chat ${chatId} after re-login...`);
-	await page.goto(`${baseUrl}/#chat-id=${chatId}`);
-	await page.reload({ waitUntil: 'networkidle' });
-	logChatCheckpoint('Page reloaded with chat hash. Waiting for messages...');
+	await page.evaluate((cid: string) => {
+		window.location.hash = `chat-id=${cid}`;
+	}, chatId);
+	// Give the hashchange handler time to process and load the chat
+	await page.waitForTimeout(3000);
+
+	// If the chat didn't load via hashchange (e.g., activeChatStore already had a
+	// different chat), fall back to a full page load with the hash
+	let userMsgAfterRelogin = page.getByTestId('message-user').first();
+	const chatLoaded = await userMsgAfterRelogin.isVisible({ timeout: 5000 }).catch(() => false);
+	if (!chatLoaded) {
+		logChatCheckpoint('Chat not loaded via hashchange, falling back to page.goto + reload...');
+		await page.goto(`${baseUrl}/#chat-id=${chatId}`);
+		await page.reload({ waitUntil: 'networkidle' });
+		logChatCheckpoint('Page reloaded with chat hash. Waiting for messages...');
+	}
 
 	// Wait for the chat to actually load — the user message must be visible.
 	// This can take longer after a fresh login (key derivation + phased sync).
-	const userMsgAfterRelogin = page.getByTestId('message-user').first();
+	userMsgAfterRelogin = page.getByTestId('message-user').first();
 	await expect(userMsgAfterRelogin).toBeVisible({ timeout: 30000 });
 
 	await takeStepScreenshot(page, '09-after-relogin');

--- a/frontend/apps/web_app/tests/chat-flow.spec.ts
+++ b/frontend/apps/web_app/tests/chat-flow.spec.ts
@@ -160,6 +160,10 @@ function extractKeyFingerprint(inspectReport: string): string | null {
  * Assert zero encryption-related errors in captured console logs.
  * Checks for CLIENT_DECRYPT failures, spurious key creation during sync,
  * and SYNC GUARD errors (which indicate missing keys during sync).
+ *
+ * IMPORTANT: Pass only the logs from the CURRENT phase (use logStartIndex to slice).
+ * The full consoleLogs buffer accumulates across all phases, and Phase 1 legitimately
+ * calls createKeyForNewChat for genuinely new chats.
  */
 function assertNoEncryptionErrors(
 	logs: string[],
@@ -800,6 +804,8 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 	logChatCheckpoint('Phase 5: Reloading tab...');
 	// Reset warn/error buffer so we only capture errors from the reload phase
 	warnErrorLogs.length = 0;
+	// Capture log offset — encryption assertions should only check logs from THIS phase
+	const phase5LogStart = consoleLogs.length;
 
 	// Navigate to the chat URL and reload to ensure a fresh startup with the hash.
 	// After Phase 4.5 we're on the home page; a plain reload would reload `/`
@@ -835,8 +841,8 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 		}
 	}
 
-	// Assert no encryption errors during the reload phase
-	assertNoEncryptionErrors(consoleLogs, chatId, logChatCheckpoint, 'after_reload');
+	// Assert no encryption errors during the reload phase (only logs from Phase 5 onward)
+	assertNoEncryptionErrors(consoleLogs.slice(phase5LogStart), chatId, logChatCheckpoint, 'after_reload');
 
 	// Save any warn/error logs from the reload phase
 	if (warnErrorLogs.length > 0) {
@@ -881,6 +887,8 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 	// PHASE 7: Login again + navigate to the same chat
 	// =========================================================================
 	logChatCheckpoint('Phase 7: Logging in again...');
+	// Capture log offset — encryption assertions should only check logs from THIS phase
+	const phase7LogStart = consoleLogs.length;
 	await performLogin(page, logChatCheckpoint, takeStepScreenshot, '08');
 
 	// Navigate directly to the test chat.
@@ -924,10 +932,10 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 		}
 	}
 
-	// CRITICAL: Assert no encryption errors after re-login.
+	// CRITICAL: Assert no encryption errors after re-login (only logs from Phase 7 onward).
 	// This catches the exact bug where encryptChatForStorage created new keys
 	// during phased sync after logout/login, corrupting existing messages.
-	assertNoEncryptionErrors(consoleLogs, chatId, logChatCheckpoint, 'after_relogin');
+	assertNoEncryptionErrors(consoleLogs.slice(phase7LogStart), chatId, logChatCheckpoint, 'after_relogin');
 
 	// Verify no missing translations on the chat page after re-login
 	await assertNoMissingTranslations(page);

--- a/frontend/apps/web_app/tests/chat-flow.spec.ts
+++ b/frontend/apps/web_app/tests/chat-flow.spec.ts
@@ -702,17 +702,25 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 	// NOTE: assertChatDecryptedCorrectly opens the sidebar, checks it, then closes it.
 	await assertChatDecryptedCorrectly(page, logChatCheckpoint, 'initial');
 
-	// Capture the chat title from the ChatHeader component for later comparison
-	// (the header is always visible regardless of sidebar state).
+	// Verify ChatHeader is fully loaded with title, summary, and icon.
+	// These are populated by the AI after processing the first message.
 	const chatHeaderTitle = page.getByTestId('chat-header-title');
 	let headerTitleText = '';
-	try {
-		await expect(chatHeaderTitle).toBeVisible({ timeout: 5000 });
-		headerTitleText = (await chatHeaderTitle.textContent())?.trim() || '';
-		logChatCheckpoint(`ChatHeader title captured: "${headerTitleText}"`);
-	} catch {
-		logChatCheckpoint('ChatHeader title not visible — skipping capture.');
-	}
+	await expect(chatHeaderTitle).toBeVisible({ timeout: 15000 });
+	headerTitleText = (await chatHeaderTitle.textContent())?.trim() || '';
+	logChatCheckpoint(`ChatHeader title: "${headerTitleText}"`);
+	expect(headerTitleText).toBeTruthy();
+	expect(headerTitleText.toLowerCase()).not.toContain('untitled');
+
+	const chatHeaderIcon = page.getByTestId('chat-header-icon');
+	await expect(chatHeaderIcon).toBeVisible({ timeout: 10000 });
+	logChatCheckpoint('ChatHeader icon visible.');
+
+	const chatHeaderSummary = page.getByTestId('chat-header-summary');
+	await expect(chatHeaderSummary).toBeVisible({ timeout: 10000 });
+	const summaryText = (await chatHeaderSummary.textContent())?.trim() || '';
+	logChatCheckpoint(`ChatHeader summary: "${summaryText}"`);
+	expect(summaryText).toBeTruthy();
 
 	// Verify no missing translations on the chat page
 	await assertNoMissingTranslations(page);

--- a/frontend/apps/web_app/tests/chat-flow.spec.ts
+++ b/frontend/apps/web_app/tests/chat-flow.spec.ts
@@ -143,6 +143,68 @@ async function inspectChatClientSide(
 }
 
 /**
+ * Extract the chat key fingerprint from an inspectChat report string.
+ * The report line looks like: "Key: abcdef1234567890 (16 bytes, source: cache)"
+ * or "Key: abcdef1234567890 [pass hideKeys:false to show full key]"
+ * Returns the fingerprint (first 8-16 hex chars) or null if not found.
+ */
+function extractKeyFingerprint(inspectReport: string): string | null {
+	const keyLine = inspectReport.split('\n').find(l => l.startsWith('Key:'));
+	if (!keyLine) return null;
+	// Extract the hex fingerprint after "Key: "
+	const match = keyLine.match(/^Key:\s+([0-9a-f]+)/i);
+	return match ? match[1] : null;
+}
+
+/**
+ * Assert zero encryption-related errors in captured console logs.
+ * Checks for CLIENT_DECRYPT failures, spurious key creation during sync,
+ * and SYNC GUARD errors (which indicate missing keys during sync).
+ */
+function assertNoEncryptionErrors(
+	logs: string[],
+	chatId: string,
+	logCheckpoint: (...args: any[]) => void,
+	phase: string
+): void {
+	// 1. No CLIENT_DECRYPT failures — these mean messages could not be decrypted
+	const decryptErrors = logs.filter(l => l.includes('CLIENT_DECRYPT') && l.includes('Failed'));
+	if (decryptErrors.length > 0) {
+		logCheckpoint(`[${phase}] ❌ Found ${decryptErrors.length} CLIENT_DECRYPT failure(s):`);
+		decryptErrors.slice(0, 3).forEach(e => logCheckpoint(`  ${e.substring(0, 200)}`));
+	}
+	expect(decryptErrors.length).toBe(0);
+
+	// 2. No createKeyForNewChat for the test chat — this would mean the sync
+	//    created a NEW random key, corrupting existing messages
+	const spuriousKeyCreation = logs.filter(
+		l => l.includes('Created new chat key for originator chat') && l.includes(chatId)
+	);
+	if (spuriousKeyCreation.length > 0) {
+		logCheckpoint(
+			`[${phase}] ❌ Sync created a NEW key for existing chat ${chatId} — ` +
+			`this would corrupt all existing messages!`
+		);
+	}
+	expect(spuriousKeyCreation.length).toBe(0);
+
+	// 3. No SYNC GUARD errors — these indicate a chat was synced without a key
+	const syncGuardErrors = logs.filter(l => l.includes('SYNC GUARD'));
+	if (syncGuardErrors.length > 0) {
+		logCheckpoint(
+			`[${phase}] ⚠️ Found ${syncGuardErrors.length} SYNC GUARD error(s) — ` +
+			`chats were synced without encryption keys`
+		);
+		syncGuardErrors.slice(0, 3).forEach(e => logCheckpoint(`  ${e.substring(0, 200)}`));
+	}
+	// SYNC GUARD for OTHER chats is a warning, not a failure — only fail if it's our test chat
+	const syncGuardForTestChat = syncGuardErrors.filter(l => l.includes(chatId));
+	expect(syncGuardForTestChat.length).toBe(0);
+
+	logCheckpoint(`[${phase}] ✅ No encryption errors detected.`);
+}
+
+/**
  * Ensure the sidebar (chats panel) is open.
  * The sidebar defaults to CLOSED — this helper clicks the menu toggle to open it
  * and waits for the Chats component to mount and render.
@@ -600,6 +662,8 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 	// PHASE 3: Client-side data check via window.inspectChat
 	// =========================================================================
 	logChatCheckpoint('Phase 3: Inspecting client-side data via window.inspectChat...');
+	// Track key fingerprint across phases to detect key corruption
+	let initialKeyFingerprint: string | null = null;
 	const inspectResult = await inspectChatClientSide(page, chatId);
 	if (inspectResult) {
 		if (inspectResult.error) {
@@ -617,6 +681,12 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 			const messageMatches = (rawReport.match(/\[(assistant|user\s*)\]/g) || []).length;
 			logChatCheckpoint(`Message count in inspectChat report: ${messageMatches}`);
 			expect(messageMatches).toBeGreaterThanOrEqual(2);
+
+			// Capture key fingerprint for cross-phase consistency check
+			initialKeyFingerprint = extractKeyFingerprint(rawReport);
+			logChatCheckpoint(`Key fingerprint (initial): ${initialKeyFingerprint}`);
+			expect(initialKeyFingerprint).toBeTruthy();
+			expect(initialKeyFingerprint).not.toBe('N/A');
 		}
 	} else {
 		logChatCheckpoint('window.inspectChat not available — skipping client-side data check.');
@@ -755,7 +825,18 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 		const messageMatches = (rawReport.match(/\[(assistant|user\s*)\]/g) || []).length;
 		logChatCheckpoint(`Message count in inspectChat after reload: ${messageMatches}`);
 		expect(messageMatches).toBeGreaterThanOrEqual(2);
+
+		// Key fingerprint must match the initial phase — reload must not change the key
+		const reloadFingerprint = extractKeyFingerprint(rawReport);
+		logChatCheckpoint(`Key fingerprint (after reload): ${reloadFingerprint}`);
+		if (initialKeyFingerprint && reloadFingerprint) {
+			expect(reloadFingerprint).toBe(initialKeyFingerprint);
+			logChatCheckpoint('✅ Key fingerprint matches initial phase after reload.');
+		}
 	}
+
+	// Assert no encryption errors during the reload phase
+	assertNoEncryptionErrors(consoleLogs, chatId, logChatCheckpoint, 'after_reload');
 
 	// Save any warn/error logs from the reload phase
 	if (warnErrorLogs.length > 0) {
@@ -830,7 +911,23 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 		const messageMatches = (rawReport.match(/\[(assistant|user\s*)\]/g) || []).length;
 		logChatCheckpoint(`Message count in inspectChat after re-login: ${messageMatches}`);
 		expect(messageMatches).toBeGreaterThanOrEqual(2);
+
+		// CRITICAL: Key fingerprint must be identical after logout/login cycle.
+		// If this fails, the sync created a new key and corrupted the chat.
+		const reloginFingerprint = extractKeyFingerprint(rawReport);
+		logChatCheckpoint(`Key fingerprint (after re-login): ${reloginFingerprint}`);
+		if (initialKeyFingerprint && reloginFingerprint) {
+			expect(reloginFingerprint).toBe(initialKeyFingerprint);
+			logChatCheckpoint(
+				'✅ Key fingerprint matches initial phase after logout/login — no key corruption.'
+			);
+		}
 	}
+
+	// CRITICAL: Assert no encryption errors after re-login.
+	// This catches the exact bug where encryptChatForStorage created new keys
+	// during phased sync after logout/login, corrupting existing messages.
+	assertNoEncryptionErrors(consoleLogs, chatId, logChatCheckpoint, 'after_relogin');
 
 	// Verify no missing translations on the chat page after re-login
 	await assertNoMissingTranslations(page);

--- a/frontend/apps/web_app/tests/signup-flow-helpers.ts
+++ b/frontend/apps/web_app/tests/signup-flow-helpers.ts
@@ -360,9 +360,15 @@ function buildSignupEmail(domain: string): string {
 	const day = String(now.getDate()).padStart(2, '0');
 	const hour = String(now.getHours()).padStart(2, '0');
 	const minute = String(now.getMinutes()).padStart(2, '0');
-	const timePart = `${month}${day}${hour}${minute}`;
+	const second = String(now.getSeconds()).padStart(2, '0');
+	// Add seconds + 3-char random suffix so concurrent signup specs (dispatched in
+	// the same batch) never generate the same email address.  Without this, all
+	// signup tests in a daily run share one email and their verification codes
+	// collide in the cache — only the last to verify succeeds.
+	const rand = Math.random().toString(36).slice(2, 5);
+	const timePart = `${month}${day}${hour}${minute}${second}${rand}`;
 
-	// Gmail +alias mode: openmates-e2e+jan151333@gmail.com
+	// Gmail +alias mode: openmates-e2e+jan15133342abc@gmail.com
 	const gmailTestAddress = process.env.GMAIL_TEST_ADDRESS;
 	if (gmailTestAddress && gmailTestAddress.includes('@')) {
 		const [localPart, gmailDomain] = gmailTestAddress.split('@');

--- a/frontend/apps/web_app/tests/signup-flow-passkey.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow-passkey.spec.ts
@@ -207,7 +207,7 @@ test('completes passkey signup flow with email + purchase', async ({
 		// Basics step: fill email/username and exercise key toggles.
 		const emailInput = page.locator('input[type="email"][autocomplete="email"]');
 		const usernameInput = page.locator('input[autocomplete="username"]');
-		await expect(emailInput).toBeVisible({ timeout: 15000 });
+		await expect(emailInput).toBeVisible({ timeout: 10000 });
 		await emailInput.fill(signupEmail);
 		await usernameInput.fill(signupUsername);
 		await takeStepScreenshot(page, 'basics-filled');
@@ -240,7 +240,7 @@ test('completes passkey signup flow with email + purchase', async ({
 		// Confirm email step: wait for step transition and verify "Open mail app" link.
 		// The step transition may take a moment, so we wait for the link to appear with a longer timeout.
 		const openMailLink = page.getByRole('link', { name: /open mail app/i });
-		await expect(openMailLink).toBeVisible({ timeout: 15000 });
+		await expect(openMailLink).toBeVisible({ timeout: 10000 });
 		await takeStepScreenshot(page, 'confirm-email');
 		await expect(openMailLink).toHaveAttribute('href', /^mailto:/i);
 
@@ -260,14 +260,14 @@ test('completes passkey signup flow with email + purchase', async ({
 
 		// Secure account step: choose passkey-based setup.
 		const passkeyOption = page.locator('#signup-passkey-option');
-		await expect(passkeyOption).toBeVisible({ timeout: 15000 });
+		await expect(passkeyOption).toBeVisible({ timeout: 10000 });
 		await takeStepScreenshot(page, 'secure-account');
 		await passkeyOption.click();
 		logSignupCheckpoint('Selected passkey signup path.');
 
 		// Recovery key step: wait for passkey registration to complete and the next step to appear.
 		const recoveryDownloadButton = page.locator('#signup-recovery-key-download');
-		await expect(recoveryDownloadButton).toBeVisible({ timeout: 60000 });
+		await expect(recoveryDownloadButton).toBeVisible({ timeout: 10000 });
 		await takeStepScreenshot(page, 'recovery-key');
 		logSignupCheckpoint('Reached recovery key step after passkey registration.');
 
@@ -337,7 +337,7 @@ test('completes passkey signup flow with email + purchase', async ({
 		const cardInputWait = stripeIframe
 			.locator('input[name="number"], input[name="cardNumber"], input[autocomplete="cc-number"]')
 			.first();
-		await cardInputWait.waitFor({ state: 'visible', timeout: 60000 });
+		await cardInputWait.waitFor({ state: 'visible', timeout: 30000 });
 		logSignupCheckpoint('Stripe Payment Element loaded.');
 
 		await takeStepScreenshot(page, 'payment-form');
@@ -348,7 +348,7 @@ test('completes passkey signup flow with email + purchase', async ({
 
 		// Wait for Stripe to validate the card (buy button enabled).
 		const buyButton = page.getByTestId('payment-form').getByTestId('buy-button');
-		await expect(buyButton).toBeEnabled({ timeout: 15000 });
+		await expect(buyButton).toBeEnabled({ timeout: 10000 });
 
 		// Submit payment and wait for success.
 		const paymentSubmittedAt = new Date().toISOString();
@@ -428,7 +428,7 @@ test('completes passkey signup flow with email + purchase', async ({
 		const deleteConfirmToggle = page
 			.getByTestId('delete-account-container').locator('input[type="checkbox"]')
 			.first();
-		await expect(deleteConfirmToggle).toBeAttached({ timeout: 60000 });
+		await expect(deleteConfirmToggle).toBeAttached({ timeout: 10000 });
 		await setToggleChecked(deleteConfirmToggle, true);
 		await takeStepScreenshot(page, 'delete-account-confirmed');
 		logSignupCheckpoint('Confirmed delete account data warning.');
@@ -442,14 +442,14 @@ test('completes passkey signup flow with email + purchase', async ({
 
 		// Wait for deletion success after passkey authentication completes.
 		await expect(page.getByTestId('delete-account-container').getByTestId('success-message')).toBeVisible({
-			timeout: 60000
+			timeout: 10000
 		});
 		await takeStepScreenshot(page, 'delete-account-success');
 		logSignupCheckpoint('Account deletion confirmed via passkey.');
 
 		// Confirm logout redirect to demo chat after deletion.
 		await page.waitForFunction(() => window.location.hash.includes('demo-for-everyone'), null, {
-			timeout: 60000
+			timeout: 10000
 		});
 		logSignupCheckpoint('Returned to demo chat after account deletion.');
 	} finally {

--- a/frontend/apps/web_app/tests/signup-flow-passkey.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow-passkey.spec.ts
@@ -408,7 +408,7 @@ test('completes passkey signup flow with email + purchase', async ({
 
 		// Confirm credits reflect the purchase (should be non-zero after payment).
 		const creditsAmount = page.getByTestId('credits-amount');
-		await expect(creditsAmount).toBeVisible();
+		await expect(creditsAmount).toBeVisible({ timeout: 10000 });
 		const creditsText = (await creditsAmount.textContent()) || '';
 		const creditsValue = Number.parseInt(creditsText.replace(/[^\d]/g, ''), 10);
 		expect(creditsValue, 'Expected purchased credits to be visible in settings.').toBeGreaterThan(

--- a/frontend/apps/web_app/tests/signup-flow-passkey.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow-passkey.spec.ts
@@ -332,25 +332,27 @@ test('completes passkey signup flow with email + purchase', async ({
 			logSignupCheckpoint('Switched from Polar to Stripe payment provider.');
 		}
 
-		await takeStepScreenshot(page, 'payment-form');
+		// Wait for Stripe Payment Element iframe to load after provider switch.
+		const stripeIframe = page.frameLocator('iframe[title="Secure payment input frame"]');
+		const cardInputWait = stripeIframe
+			.locator('input[name="number"], input[name="cardNumber"], input[autocomplete="cc-number"]')
+			.first();
+		await cardInputWait.waitFor({ state: 'visible', timeout: 60000 });
+		logSignupCheckpoint('Stripe Payment Element loaded.');
 
-		// Payment security info button should open a Stripe privacy page (close immediately).
-		const securityInfoButton = page.getByTestId('payment-form').getByTestId('text-button').first();
-		await securityInfoButton.scrollIntoViewIfNeeded();
-		const [securityInfoPage] = await Promise.all([
-			context.waitForEvent('page'),
-			securityInfoButton.click()
-		]);
-		await securityInfoPage.close();
-		logSignupCheckpoint('Closed payment security info page.');
+		await takeStepScreenshot(page, 'payment-form');
 
 		// Fill Stripe payment element with the test card.
 		await fillStripeCardDetails(page, STRIPE_TEST_CARD_NUMBER);
 		logSignupCheckpoint('Filled Stripe card details.');
 
+		// Wait for Stripe to validate the card (buy button enabled).
+		const buyButton = page.getByTestId('payment-form').getByTestId('buy-button');
+		await expect(buyButton).toBeEnabled({ timeout: 15000 });
+
 		// Submit payment and wait for success.
 		const paymentSubmittedAt = new Date().toISOString();
-		await page.getByTestId('payment-form').getByTestId('buy-button').click();
+		await buyButton.click();
 		await expect(page.getByText(/purchase successful/i)).toBeVisible({ timeout: 60000 });
 		await takeStepScreenshot(page, 'payment-success');
 		logSignupCheckpoint('Purchase completed successfully.');

--- a/frontend/apps/web_app/tests/signup-flow-passkey.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow-passkey.spec.ts
@@ -319,10 +319,20 @@ test('completes passkey signup flow with email + purchase', async ({
 		logSignupCheckpoint('Reached payment consent step.');
 
 		// Payment step: consent to limited refund to reveal payment form.
+		// Dismiss consent overlay BEFORE switching providers (it blocks pointer events).
 		const consentToggle = page.locator('#limited-refund-consent-toggle');
 		await setToggleChecked(consentToggle, true);
-		await takeStepScreenshot(page, 'payment-form');
 		logSignupCheckpoint('Payment consent accepted.');
+
+		// GHA runners are in the US, so Polar is auto-selected (non-EU IP).
+		// Switch to Stripe for this test — it specifically tests the Stripe payment flow.
+		const switchToStripeBtn = page.getByTestId('switch-to-stripe');
+		if (await switchToStripeBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+			await switchToStripeBtn.click();
+			logSignupCheckpoint('Switched from Polar to Stripe payment provider.');
+		}
+
+		await takeStepScreenshot(page, 'payment-form');
 
 		// Payment security info button should open a Stripe privacy page (close immediately).
 		const securityInfoButton = page.getByTestId('payment-form').getByTestId('text-button').first();

--- a/frontend/apps/web_app/tests/signup-flow-polar.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow-polar.spec.ts
@@ -456,6 +456,39 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	const billingCountrySelect = polarIframe.locator('select[autocomplete="billing country"]');
 	await expect(billingCountrySelect).toBeVisible({ timeout: 10000 });
 	await billingCountrySelect.selectOption('US');
+
+	// US billing requires address, city, state, and ZIP — fill them after selecting country
+	// so the form has time to render the address fields (some providers show them conditionally).
+	const billingAddress = polarIframe.locator('input[name="customer_billing_address_line1"], input[autocomplete="billing address-line1"], input[placeholder*="Address"]').first();
+	if (await billingAddress.isVisible({ timeout: 5000 }).catch(() => false)) {
+		await billingAddress.fill('123 Test Street');
+
+		const billingCity = polarIframe.locator('input[name="customer_billing_address_city"], input[autocomplete="billing address-level2"], input[placeholder*="City"]').first();
+		if (await billingCity.isVisible({ timeout: 3000 }).catch(() => false)) {
+			await billingCity.fill('New York');
+		}
+
+		const billingState = polarIframe.locator('input[name="customer_billing_address_state"], input[autocomplete="billing address-level1"], input[placeholder*="State"], select[name="customer_billing_address_state"], select[autocomplete="billing address-level1"]').first();
+		if (await billingState.isVisible({ timeout: 3000 }).catch(() => false)) {
+			// Try select first, then input
+			const tagName = await billingState.evaluate((el: Element) => el.tagName.toLowerCase());
+			if (tagName === 'select') {
+				await billingState.selectOption('NY');
+			} else {
+				await billingState.fill('NY');
+			}
+		}
+
+		const billingZip = polarIframe.locator('input[name="customer_billing_address_postal_code"], input[autocomplete="billing postal-code"], input[placeholder*="ZIP"], input[placeholder*="Postal"]').first();
+		if (await billingZip.isVisible({ timeout: 3000 }).catch(() => false)) {
+			await billingZip.fill('10001');
+		}
+
+		logSignupCheckpoint('Filled billing address, city, state, and ZIP.');
+	} else {
+		logSignupCheckpoint('Billing address fields not visible — Polar may not require them for this flow.');
+	}
+
 	logSignupCheckpoint('Filled cardholder name and billing country.');
 
 	await takeStepScreenshot(page, 'polar-card-filled');
@@ -571,7 +604,7 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	await expect(authModal).toBeVisible();
 	await takeStepScreenshot(page, 'delete-account-auth');
 
-	const deleteOtpInput = authModal.locator('input.tfa-input');
+	const deleteOtpInput = authModal.getByTestId('tfa-input');
 	await expect(deleteOtpInput).toBeVisible();
 	await deleteOtpInput.fill(generateTotp(tfaSecret));
 	logSignupCheckpoint('Submitted 2FA code to confirm account deletion.');

--- a/frontend/apps/web_app/tests/signup-flow-polar.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow-polar.spec.ts
@@ -225,7 +225,7 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 
 	const emailInput = page.locator('input[type="email"][autocomplete="email"]');
 	const usernameInput = page.locator('input[autocomplete="username"]');
-	await expect(emailInput).toBeVisible({ timeout: 15000 });
+	await expect(emailInput).toBeVisible({ timeout: 10000 });
 	await emailInput.fill(signupEmail);
 	await usernameInput.fill(signupUsername);
 	await takeStepScreenshot(page, 'basics-filled');
@@ -248,7 +248,7 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	// ─── Email confirmation ───────────────────────────────────────────────────────
 
 	const openMailLink = page.getByRole('link', { name: /open mail app/i });
-	await expect(openMailLink).toBeVisible({ timeout: 15000 });
+	await expect(openMailLink).toBeVisible({ timeout: 10000 });
 	await takeStepScreenshot(page, 'confirm-email');
 
 	logSignupCheckpoint('Polling Mailosaur for confirmation email.');
@@ -266,7 +266,7 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	// ─── Password setup ───────────────────────────────────────────────────────────
 
 	const passwordOption = page.locator('#signup-password-option');
-	await expect(passwordOption).toBeVisible({ timeout: 15000 });
+	await expect(passwordOption).toBeVisible({ timeout: 10000 });
 	await takeStepScreenshot(page, 'secure-account');
 	await passwordOption.click();
 	await takeStepScreenshot(page, 'password-step');
@@ -369,7 +369,7 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	// The consent overlay appears regardless of whether the initial provider is Stripe or Polar.
 
 	const consentToggle = page.locator('#limited-refund-consent-toggle');
-	await expect(consentToggle).toBeAttached({ timeout: 15000 });
+	await expect(consentToggle).toBeAttached({ timeout: 10000 });
 	await setToggleChecked(consentToggle, true);
 	await takeStepScreenshot(page, 'payment-consent-accepted');
 	logSignupCheckpoint('Payment consent accepted.');
@@ -418,7 +418,7 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	// Wait for the Polar iframe to load by checking for a visible element inside it.
 	// Polar's checkout page renders a submit button — use that as the load indicator.
 	await expect(polarIframe.getByRole('button', { name: /pay|subscribe|complete/i }).first())
-		.toBeVisible({ timeout: 60000 });
+		.toBeVisible({ timeout: 30000 });
 	await takeStepScreenshot(page, 'polar-checkout-overlay');
 	logSignupCheckpoint('Polar checkout overlay visible.');
 
@@ -450,11 +450,11 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	// Polar's checkout requires cardholder name and billing country.
 	// These fields are in the Polar iframe directly (not the nested Stripe iframe).
 	const cardholderNameInput = polarIframe.locator('input[name="customer_name"]');
-	await expect(cardholderNameInput).toBeVisible({ timeout: 5000 });
+	await expect(cardholderNameInput).toBeVisible({ timeout: 10000 });
 	await cardholderNameInput.fill('Test User');
 
 	const billingCountrySelect = polarIframe.locator('select[autocomplete="billing country"]');
-	await expect(billingCountrySelect).toBeVisible({ timeout: 5000 });
+	await expect(billingCountrySelect).toBeVisible({ timeout: 10000 });
 	await billingCountrySelect.selectOption('US');
 	logSignupCheckpoint('Filled cardholder name and billing country.');
 
@@ -466,14 +466,14 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	const polarSubmitButton = polarIframe
 		.getByRole('button', { name: /pay|subscribe|complete/i })
 		.first();
-	await expect(polarSubmitButton).toBeVisible({ timeout: 15000 });
+	await expect(polarSubmitButton).toBeVisible({ timeout: 30000 });
 	await polarSubmitButton.click();
 	logSignupCheckpoint('Submitted Polar checkout form.');
 
 	// After Polar processes the payment, the overlay fires a 'success' event and our
 	// Payment.svelte transitions to the ProcessingPayment / success state.
 	// Wait for "purchase successful" to appear in the main page (not inside the iframe).
-	await expect(page.getByText(/purchase successful/i)).toBeVisible({ timeout: 120000 });
+	await expect(page.getByText(/purchase successful/i)).toBeVisible({ timeout: 60000 });
 	await takeStepScreenshot(page, 'polar-payment-success');
 	logSignupCheckpoint('Polar purchase completed successfully.');
 
@@ -561,7 +561,7 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	const deleteConfirmToggle = page
 		.getByTestId('delete-account-container').locator('input[type="checkbox"]')
 		.first();
-	await expect(deleteConfirmToggle).toBeAttached({ timeout: 60000 });
+	await expect(deleteConfirmToggle).toBeAttached({ timeout: 10000 });
 	await setToggleChecked(deleteConfirmToggle, true);
 	await takeStepScreenshot(page, 'delete-account-confirmed');
 	logSignupCheckpoint('Confirmed delete account data warning.');
@@ -577,13 +577,13 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	logSignupCheckpoint('Submitted 2FA code to confirm account deletion.');
 
 	await expect(page.getByTestId('delete-account-container').getByTestId('success-message')).toBeVisible({
-		timeout: 60000
+		timeout: 10000
 	});
 	await takeStepScreenshot(page, 'delete-account-success');
 	logSignupCheckpoint('Account deletion confirmed.');
 
 	await page.waitForFunction(() => window.location.hash.includes('demo-for-everyone'), null, {
-		timeout: 60000
+		timeout: 10000
 	});
 	logSignupCheckpoint('Returned to demo chat after account deletion.');
 });

--- a/frontend/apps/web_app/tests/signup-flow-polar.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow-polar.spec.ts
@@ -538,7 +538,7 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	logSignupCheckpoint('Opened settings menu for credit verification.');
 
 	const creditsAmount = page.getByTestId('credits-amount');
-	await expect(creditsAmount).toBeVisible();
+	await expect(creditsAmount).toBeVisible({ timeout: 10000 });
 	const creditsText = (await creditsAmount.textContent()) || '';
 	const creditsValue = Number.parseInt(creditsText.replace(/[^\d]/g, ''), 10);
 	expect(

--- a/frontend/apps/web_app/tests/signup-flow-polar.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow-polar.spec.ts
@@ -457,37 +457,54 @@ test('completes full Polar signup flow with email + 2FA + non-EU payment', async
 	await expect(billingCountrySelect).toBeVisible({ timeout: 10000 });
 	await billingCountrySelect.selectOption('US');
 
-	// US billing requires address, city, state, and ZIP — fill them after selecting country
-	// so the form has time to render the address fields (some providers show them conditionally).
-	const billingAddress = polarIframe.locator('input[name="customer_billing_address_line1"], input[autocomplete="billing address-line1"], input[placeholder*="Address"]').first();
-	if (await billingAddress.isVisible({ timeout: 5000 }).catch(() => false)) {
+	// US billing requires address, city, state, and ZIP — fill them after selecting country.
+	// Polar renders these fields in the checkout iframe. Use broad locator strategies:
+	// label text, placeholder text, and common name/autocomplete attributes.
+	// Wait longer (10s) since fields may render after country selection.
+	await page.waitForTimeout(2000); // Let Polar render address fields after country change
+
+	// Billing address line 1 — try label, placeholder, then name attribute patterns
+	const billingAddress = polarIframe.getByLabel(/billing address|address line 1|street address/i).first()
+		.or(polarIframe.locator('input[placeholder*="address" i]').first())
+		.or(polarIframe.locator('input[name*="address_line1"], input[name*="billing_address"], input[name*="address1"]').first());
+	if (await billingAddress.isVisible({ timeout: 10000 }).catch(() => false)) {
 		await billingAddress.fill('123 Test Street');
-
-		const billingCity = polarIframe.locator('input[name="customer_billing_address_city"], input[autocomplete="billing address-level2"], input[placeholder*="City"]').first();
-		if (await billingCity.isVisible({ timeout: 3000 }).catch(() => false)) {
-			await billingCity.fill('New York');
-		}
-
-		const billingState = polarIframe.locator('input[name="customer_billing_address_state"], input[autocomplete="billing address-level1"], input[placeholder*="State"], select[name="customer_billing_address_state"], select[autocomplete="billing address-level1"]').first();
-		if (await billingState.isVisible({ timeout: 3000 }).catch(() => false)) {
-			// Try select first, then input
-			const tagName = await billingState.evaluate((el: Element) => el.tagName.toLowerCase());
-			if (tagName === 'select') {
-				await billingState.selectOption('NY');
-			} else {
-				await billingState.fill('NY');
-			}
-		}
-
-		const billingZip = polarIframe.locator('input[name="customer_billing_address_postal_code"], input[autocomplete="billing postal-code"], input[placeholder*="ZIP"], input[placeholder*="Postal"]').first();
-		if (await billingZip.isVisible({ timeout: 3000 }).catch(() => false)) {
-			await billingZip.fill('10001');
-		}
-
-		logSignupCheckpoint('Filled billing address, city, state, and ZIP.');
+		logSignupCheckpoint('Filled billing address line 1.');
 	} else {
-		logSignupCheckpoint('Billing address fields not visible — Polar may not require them for this flow.');
+		logSignupCheckpoint('WARNING: Billing address field not found — payment may fail.');
 	}
+
+	// City
+	const billingCity = polarIframe.getByLabel(/city/i).first()
+		.or(polarIframe.locator('input[placeholder*="city" i]').first())
+		.or(polarIframe.locator('input[name*="city"]').first());
+	if (await billingCity.isVisible({ timeout: 5000 }).catch(() => false)) {
+		await billingCity.fill('New York');
+		logSignupCheckpoint('Filled billing city.');
+	}
+
+	// State — can be input or select
+	const billingStateInput = polarIframe.getByLabel(/state|province|region/i).first()
+		.or(polarIframe.locator('input[placeholder*="state" i], input[name*="state"]').first());
+	const billingStateSelect = polarIframe.locator('select[name*="state"], select[autocomplete*="address-level1"]').first();
+	if (await billingStateSelect.isVisible({ timeout: 3000 }).catch(() => false)) {
+		await billingStateSelect.selectOption('NY');
+		logSignupCheckpoint('Selected billing state (dropdown).');
+	} else if (await billingStateInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+		await billingStateInput.fill('NY');
+		logSignupCheckpoint('Filled billing state (input).');
+	}
+
+	// ZIP / Postal code
+	const billingZip = polarIframe.getByLabel(/zip|postal/i).first()
+		.or(polarIframe.locator('input[placeholder*="zip" i], input[placeholder*="postal" i]').first())
+		.or(polarIframe.locator('input[name*="postal"], input[name*="zip"]').first());
+	if (await billingZip.isVisible({ timeout: 5000 }).catch(() => false)) {
+		await billingZip.fill('10001');
+		logSignupCheckpoint('Filled billing ZIP code.');
+	}
+
+	await takeStepScreenshot(page, 'polar-billing-filled');
 
 	logSignupCheckpoint('Filled cardholder name and billing country.');
 

--- a/frontend/apps/web_app/tests/signup-flow.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow.spec.ts
@@ -174,7 +174,7 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 	// Basics step: fill email/username and exercise key toggles.
 	const emailInput = page.locator('input[type="email"][autocomplete="email"]');
 	const usernameInput = page.locator('input[autocomplete="username"]');
-	await expect(emailInput).toBeVisible({ timeout: 15000 });
+	await expect(emailInput).toBeVisible({ timeout: 10000 });
 	await emailInput.fill(signupEmail);
 	await usernameInput.fill(signupUsername);
 	await takeStepScreenshot(page, 'basics-filled');
@@ -207,7 +207,7 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 	// Confirm email step: wait for step transition and verify "Open mail app" link.
 	// The step transition may take a moment, so we wait for the link to appear with a longer timeout.
 	const openMailLink = page.getByRole('link', { name: /open mail app/i });
-	await expect(openMailLink).toBeVisible({ timeout: 15000 });
+	await expect(openMailLink).toBeVisible({ timeout: 10000 });
 	await takeStepScreenshot(page, 'confirm-email');
 	await expect(openMailLink).toHaveAttribute('href', /^mailto:/i);
 
@@ -225,7 +225,7 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 
 	// Secure account step: choose password-based setup.
 	const passwordOption = page.locator('#signup-password-option');
-	await expect(passwordOption).toBeVisible({ timeout: 15000 });
+	await expect(passwordOption).toBeVisible({ timeout: 10000 });
 	await takeStepScreenshot(page, 'secure-account');
 	await passwordOption.click();
 	await takeStepScreenshot(page, 'password-step');
@@ -376,7 +376,7 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 	const cardInput = stripeIframe
 		.locator('input[name="number"], input[name="cardNumber"], input[autocomplete="cc-number"]')
 		.first();
-	await cardInput.waitFor({ state: 'visible', timeout: 60000 });
+	await cardInput.waitFor({ state: 'visible', timeout: 30000 });
 	logSignupCheckpoint('Stripe Payment Element loaded.');
 
 	await takeStepScreenshot(page, 'payment-form');
@@ -387,7 +387,7 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 
 	// Wait for Stripe to validate the card (isPaymentElementComplete → buy button enabled).
 	const buyButton = page.getByTestId('payment-form').getByTestId('buy-button');
-	await expect(buyButton).toBeEnabled({ timeout: 15000 });
+	await expect(buyButton).toBeEnabled({ timeout: 10000 });
 
 	// Submit payment and wait for success.
 	const paymentSubmittedAt = new Date().toISOString();
@@ -466,7 +466,7 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 	const deleteConfirmToggle = page
 		.getByTestId('delete-account-container').locator('input[type="checkbox"]')
 		.first();
-	await expect(deleteConfirmToggle).toBeAttached({ timeout: 60000 });
+	await expect(deleteConfirmToggle).toBeAttached({ timeout: 10000 });
 	await setToggleChecked(deleteConfirmToggle, true);
 	await takeStepScreenshot(page, 'delete-account-confirmed');
 	logSignupCheckpoint('Confirmed delete account data warning.');
@@ -483,14 +483,14 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 	logSignupCheckpoint('Submitted 2FA code to confirm account deletion.');
 
 	await expect(page.getByTestId('delete-account-container').getByTestId('success-message')).toBeVisible({
-		timeout: 60000
+		timeout: 10000
 	});
 	await takeStepScreenshot(page, 'delete-account-success');
 	logSignupCheckpoint('Account deletion confirmed.');
 
 	// Confirm logout redirect to demo chat after deletion.
 	await page.waitForFunction(() => window.location.hash.includes('demo-for-everyone'), null, {
-		timeout: 60000
+		timeout: 10000
 	});
 	logSignupCheckpoint('Returned to demo chat after account deletion.');
 });

--- a/frontend/apps/web_app/tests/signup-flow.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow.spec.ts
@@ -447,7 +447,7 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 
 	// Confirm credits reflect the purchase (should be non-zero after payment).
 	const creditsAmount = page.getByTestId('credits-amount');
-	await expect(creditsAmount).toBeVisible();
+	await expect(creditsAmount).toBeVisible({ timeout: 10000 });
 	const creditsText = (await creditsAmount.textContent()) || '';
 	const creditsValue = Number.parseInt(creditsText.replace(/[^\d]/g, ''), 10);
 	expect(creditsValue, 'Expected purchased credits to be visible in settings.').toBeGreaterThan(0);

--- a/frontend/apps/web_app/tests/signup-flow.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow.spec.ts
@@ -354,10 +354,21 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 	logSignupCheckpoint('Reached payment consent step.');
 
 	// Payment step: consent to limited refund to reveal payment form.
+	// The consent overlay must be dismissed BEFORE switching providers, because
+	// it covers the payment area with pointer-events:all.
 	const consentToggle = page.locator('#limited-refund-consent-toggle');
 	await setToggleChecked(consentToggle, true);
-	await takeStepScreenshot(page, 'payment-form');
 	logSignupCheckpoint('Payment consent accepted.');
+
+	// GHA runners are in the US, so Polar is auto-selected (non-EU IP).
+	// Switch to Stripe for this test — it specifically tests the Stripe payment flow.
+	const switchToStripeBtn = page.getByTestId('switch-to-stripe');
+	if (await switchToStripeBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+		await switchToStripeBtn.click();
+		logSignupCheckpoint('Switched from Polar to Stripe payment provider.');
+	}
+
+	await takeStepScreenshot(page, 'payment-form');
 
 	// Payment security info button should open a Stripe privacy page (close immediately).
 	const securityInfoButton = page.getByTestId('payment-form').getByTestId('text-button').first();

--- a/frontend/apps/web_app/tests/signup-flow.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow.spec.ts
@@ -99,8 +99,9 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 
 	test.slow();
 	// Allow extra time for Mailosaur email delivery + purchase confirmation + account deletion.
-	// GHA runners are slower than local — 240s was insufficient; 420s provides comfortable margin.
-	test.setTimeout(420000);
+	// This is the longest signup spec: full 2FA setup, payment, email verification of purchase,
+	// refund link validation, and account deletion with 2FA auth. 600s needed for retries.
+	test.setTimeout(600000);
 
 	const logSignupCheckpoint = createSignupLogger('SIGNUP_FLOW');
 	const takeStepScreenshot = createStepScreenshotter(logSignupCheckpoint);

--- a/frontend/apps/web_app/tests/signup-flow.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow.spec.ts
@@ -368,25 +368,30 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 		logSignupCheckpoint('Switched from Polar to Stripe payment provider.');
 	}
 
-	await takeStepScreenshot(page, 'payment-form');
+	// Wait for Stripe Payment Element iframe to load after provider switch.
+	// switchProvider() tears down Polar, fetches config, loads Stripe.js, creates
+	// a PaymentIntent, and mounts the Payment Element — all async. The iframe
+	// won't exist until that chain completes.
+	const stripeIframe = page.frameLocator('iframe[title="Secure payment input frame"]');
+	const cardInput = stripeIframe
+		.locator('input[name="number"], input[name="cardNumber"], input[autocomplete="cc-number"]')
+		.first();
+	await cardInput.waitFor({ state: 'visible', timeout: 60000 });
+	logSignupCheckpoint('Stripe Payment Element loaded.');
 
-	// Payment security info button should open a Stripe privacy page (close immediately).
-	const securityInfoButton = page.getByTestId('payment-form').getByTestId('text-button').first();
-	await securityInfoButton.scrollIntoViewIfNeeded();
-	const [securityInfoPage] = await Promise.all([
-		context.waitForEvent('page'),
-		securityInfoButton.click()
-	]);
-	await securityInfoPage.close();
-	logSignupCheckpoint('Closed payment security info page.');
+	await takeStepScreenshot(page, 'payment-form');
 
 	// Fill Stripe payment element with the test card.
 	await fillStripeCardDetails(page, STRIPE_TEST_CARD_NUMBER);
 	logSignupCheckpoint('Filled Stripe card details.');
 
+	// Wait for Stripe to validate the card (isPaymentElementComplete → buy button enabled).
+	const buyButton = page.getByTestId('payment-form').getByTestId('buy-button');
+	await expect(buyButton).toBeEnabled({ timeout: 15000 });
+
 	// Submit payment and wait for success.
 	const paymentSubmittedAt = new Date().toISOString();
-	await page.getByTestId('payment-form').getByTestId('buy-button').click();
+	await buyButton.click();
 	await expect(page.getByText(/purchase successful/i)).toBeVisible({ timeout: 60000 });
 	await takeStepScreenshot(page, 'payment-success');
 	logSignupCheckpoint('Purchase completed successfully.');

--- a/frontend/apps/web_app/tests/signup-flow.spec.ts
+++ b/frontend/apps/web_app/tests/signup-flow.spec.ts
@@ -478,8 +478,8 @@ test('completes full signup flow with email + 2FA + purchase', async ({
 	await expect(authModal).toBeVisible();
 	await takeStepScreenshot(page, 'delete-account-auth');
 
-	const deleteOtpInput = authModal.locator('input.tfa-input');
-	await expect(deleteOtpInput).toBeVisible();
+	const deleteOtpInput = authModal.getByTestId('tfa-input');
+	await expect(deleteOtpInput).toBeVisible({ timeout: 10000 });
 	await deleteOtpInput.fill(generateTotp(tfaSecret));
 	logSignupCheckpoint('Submitted 2FA code to confirm account deletion.');
 

--- a/frontend/apps/web_app/tests/signup-skip-2fa-flow.spec.ts
+++ b/frontend/apps/web_app/tests/signup-skip-2fa-flow.spec.ts
@@ -226,19 +226,30 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	if (await switchToStripeBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
 		await switchToStripeBtn.click();
 		logSignupCheckpoint('Switched from Polar to Stripe payment provider.');
-		// After switching, wait for Stripe to initialize (consent was already given,
-		// so the Stripe form should load directly without the consent overlay).
-		await expect(stripeIframe).toBeAttached({ timeout: 60000 });
-		logSignupCheckpoint('Stripe payment iframe loaded after provider switch.');
 	}
+
+	// Wait for Stripe Payment Element card input to be visible inside the iframe.
+	// switchProvider() tears down Polar, fetches config, loads Stripe.js, creates
+	// a PaymentIntent, and mounts the Payment Element — all async.
+	const stripeFrameLocator = page.frameLocator('iframe[title="Secure payment input frame"]');
+	const cardInputWait = stripeFrameLocator
+		.locator('input[name="number"], input[name="cardNumber"], input[autocomplete="cc-number"]')
+		.first();
+	await cardInputWait.waitFor({ state: 'visible', timeout: 60000 });
+	logSignupCheckpoint('Stripe Payment Element loaded.');
+
 	await takeStepScreenshot(page, 'payment-form');
 
 	// Fill Stripe payment element with the test card.
 	await fillStripeCardDetails(page, STRIPE_TEST_CARD_NUMBER);
 	logSignupCheckpoint('Filled Stripe card details.');
 
+	// Wait for Stripe to validate the card (buy button enabled).
+	const buyButton = page.getByTestId('payment-form').getByTestId('buy-button');
+	await expect(buyButton).toBeEnabled({ timeout: 15000 });
+
 	// Submit payment and wait for success.
-	await page.getByTestId('payment-form').getByTestId('buy-button').click();
+	await buyButton.click();
 	await expect(page.getByText(/purchase successful/i)).toBeVisible({ timeout: 120000 });
 	logSignupCheckpoint('Stripe payment completed successfully.');
 

--- a/frontend/apps/web_app/tests/signup-skip-2fa-flow.spec.ts
+++ b/frontend/apps/web_app/tests/signup-skip-2fa-flow.spec.ts
@@ -204,19 +204,13 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	await takeStepScreenshot(page, 'payment-consent');
 	logSignupCheckpoint('Reached payment consent step.');
 
-	// GHA runners are in the US, so Polar is auto-selected. Switch to Stripe for this test.
-	const switchToStripeBtn = page.getByTestId('switch-to-stripe');
-	if (await switchToStripeBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-		await switchToStripeBtn.click();
-		logSignupCheckpoint('Switched from Polar to Stripe payment provider.');
-	}
-
-	// After switching to Stripe, the consent toggle may or may not appear depending on
-	// whether Stripe uses the hosted invoice path or inline elements. Handle both cases.
+	// The consent overlay appears on top of the payment form regardless of provider.
+	// It must be dismissed BEFORE clicking provider-switch buttons, because the overlay
+	// has pointer-events:all and blocks clicks to elements underneath (like switch-to-stripe).
 	const consentToggle = page.locator('#limited-refund-consent-toggle');
 	const stripeIframe = page.locator('iframe[title="Secure payment input frame"]');
 
-	// Wait for either consent toggle or Stripe iframe to appear
+	// Wait for the consent toggle or Stripe iframe to appear (payment step loaded)
 	await expect(consentToggle.or(stripeIframe)).toBeAttached({ timeout: 60000 });
 
 	if (await consentToggle.isVisible().catch(() => false)) {
@@ -224,6 +218,18 @@ test('completes signup with skipped 2FA, login with password, and delete account
 		logSignupCheckpoint('Payment consent accepted.');
 	} else {
 		logSignupCheckpoint('No consent toggle — Stripe loaded directly (hosted invoice path).');
+	}
+
+	// GHA runners are in the US, so Polar is auto-selected. Switch to Stripe for this test.
+	// Now that consent overlay is dismissed, the switch button is clickable.
+	const switchToStripeBtn = page.getByTestId('switch-to-stripe');
+	if (await switchToStripeBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+		await switchToStripeBtn.click();
+		logSignupCheckpoint('Switched from Polar to Stripe payment provider.');
+		// After switching, wait for Stripe to initialize (consent was already given,
+		// so the Stripe form should load directly without the consent overlay).
+		await expect(stripeIframe).toBeAttached({ timeout: 60000 });
+		logSignupCheckpoint('Stripe payment iframe loaded after provider switch.');
 	}
 	await takeStepScreenshot(page, 'payment-form');
 

--- a/frontend/apps/web_app/tests/signup-skip-2fa-flow.spec.ts
+++ b/frontend/apps/web_app/tests/signup-skip-2fa-flow.spec.ts
@@ -135,7 +135,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 
 	const emailInput = page.locator('input[type="email"][autocomplete="email"]');
 	const usernameInput = page.locator('input[autocomplete="username"]');
-	await expect(emailInput).toBeVisible({ timeout: 15000 });
+	await expect(emailInput).toBeVisible({ timeout: 10000 });
 	await emailInput.fill(signupEmail);
 	await usernameInput.fill(signupUsername);
 
@@ -148,7 +148,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	await page.getByRole('button', { name: /create new account/i }).click();
 
 	const openMailLink = page.getByRole('link', { name: /open mail app/i });
-	await expect(openMailLink).toBeVisible({ timeout: 15000 });
+	await expect(openMailLink).toBeVisible({ timeout: 10000 });
 
 	const confirmEmailMessage = await waitForMailosaurMessage({
 		sentTo: signupEmail,
@@ -161,7 +161,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	await confirmEmailInput.fill(emailCode);
 
 	const passwordOption = page.locator('#signup-password-option');
-	await expect(passwordOption).toBeVisible({ timeout: 15000 });
+	await expect(passwordOption).toBeVisible({ timeout: 10000 });
 	await passwordOption.click();
 
 	const passwordInputs = page.locator('input[autocomplete="new-password"]');
@@ -173,10 +173,10 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	await takeStepScreenshot(page, 'one-time-codes');
 
 	const skipForNowButton = page.locator('#signup-nav-skip');
-	await expect(skipForNowButton).toBeVisible({ timeout: 20000 });
+	await expect(skipForNowButton).toBeVisible({ timeout: 10000 });
 	await skipForNowButton.click();
 
-	await expect(page.getByText(/be aware before skipping 2fa/i)).toBeVisible({ timeout: 15000 });
+	await expect(page.getByText(/be aware before skipping 2fa/i)).toBeVisible({ timeout: 10000 });
 	await takeStepScreenshot(page, 'skip-2fa-consent');
 
 	const skipConsentToggle = page.locator('#skip-2fa-consent-toggle');
@@ -198,7 +198,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	await setToggleChecked(recoveryConfirmToggle, true);
 
 	await expect(page.getByTestId('credits-package').getByTestId('buy-button').first()).toBeVisible({
-		timeout: 30000
+		timeout: 10000
 	});
 	await page.getByTestId('credits-package').getByTestId('buy-button').first().click();
 	await takeStepScreenshot(page, 'payment-consent');
@@ -211,7 +211,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	const stripeIframe = page.locator('iframe[title="Secure payment input frame"]');
 
 	// Wait for the consent toggle or Stripe iframe to appear (payment step loaded)
-	await expect(consentToggle.or(stripeIframe)).toBeAttached({ timeout: 60000 });
+	await expect(consentToggle.or(stripeIframe)).toBeAttached({ timeout: 10000 });
 
 	if (await consentToggle.isVisible().catch(() => false)) {
 		await setToggleChecked(consentToggle, true);
@@ -235,7 +235,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	const cardInputWait = stripeFrameLocator
 		.locator('input[name="number"], input[name="cardNumber"], input[autocomplete="cc-number"]')
 		.first();
-	await cardInputWait.waitFor({ state: 'visible', timeout: 60000 });
+	await cardInputWait.waitFor({ state: 'visible', timeout: 30000 });
 	logSignupCheckpoint('Stripe Payment Element loaded.');
 
 	await takeStepScreenshot(page, 'payment-form');
@@ -246,11 +246,11 @@ test('completes signup with skipped 2FA, login with password, and delete account
 
 	// Wait for Stripe to validate the card (buy button enabled).
 	const buyButton = page.getByTestId('payment-form').getByTestId('buy-button');
-	await expect(buyButton).toBeEnabled({ timeout: 15000 });
+	await expect(buyButton).toBeEnabled({ timeout: 10000 });
 
 	// Submit payment and wait for success.
 	await buyButton.click();
-	await expect(page.getByText(/purchase successful/i)).toBeVisible({ timeout: 120000 });
+	await expect(page.getByText(/purchase successful/i)).toBeVisible({ timeout: 60000 });
 	logSignupCheckpoint('Stripe payment completed successfully.');
 
 	await page.locator('#signup-finish-setup').click();
@@ -267,7 +267,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	await logoutItem.click();
 
 	await page.waitForFunction(() => window.location.hash.includes('demo-for-everyone'), null, {
-		timeout: 60000
+		timeout: 10000
 	});
 	await takeStepScreenshot(page, 'logged-out');
 
@@ -284,7 +284,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	const loginButtonAfterLogout = page.getByRole('button', {
 		name: /login.*sign up|sign up/i
 	});
-	await expect(loginButtonAfterLogout).toBeVisible({ timeout: 15000 });
+	await expect(loginButtonAfterLogout).toBeVisible({ timeout: 10000 });
 	await loginButtonAfterLogout.click();
 
 	// Switch to Login tab (dialog may default to Sign up tab after a fresh signup)
@@ -296,21 +296,21 @@ test('completes signup with skipped 2FA, login with password, and delete account
 
 	// Use broader selector to handle both login dialog variants (name="username" or id="login-email-input").
 	const emailInputRelogin = page.locator('#login-email-input, input[type="email"][name="username"]').first();
-	await expect(emailInputRelogin).toBeVisible({ timeout: 15000 });
+	await expect(emailInputRelogin).toBeVisible({ timeout: 10000 });
 	await emailInputRelogin.fill(signupEmail);
 	await page.getByRole('button', { name: /continue|next/i }).click();
 
 	const passwordInputRelogin = page.locator('#login-password-input');
-	await expect(passwordInputRelogin.first()).toBeVisible({ timeout: 15000 });
+	await expect(passwordInputRelogin.first()).toBeVisible({ timeout: 10000 });
 	await passwordInputRelogin.first().fill(signupPassword);
 
 	await expect(page.locator('#login-otp-input').first()).not.toBeVisible();
 
 	const loginSubmitButton = page.locator('button[type="submit"]', { hasText: /log in|login/i });
-	await expect(loginSubmitButton).toBeVisible({ timeout: 15000 });
+	await expect(loginSubmitButton).toBeVisible({ timeout: 10000 });
 	await loginSubmitButton.click();
 
-	await page.waitForURL(/chat/, { timeout: 60000 });
+	await page.waitForURL(/chat/, { timeout: 10000 });
 	await takeStepScreenshot(page, 'relogin-success');
 	await assertNoMissingTranslations(page);
 	logSignupCheckpoint('Re-login with password completed. No 2FA/OTP was requested.');
@@ -335,7 +335,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	const deleteConfirmToggle = page
 		.getByTestId('delete-account-container').locator('input[type="checkbox"]')
 		.first();
-	await expect(deleteConfirmToggle).toBeAttached({ timeout: 60000 });
+	await expect(deleteConfirmToggle).toBeAttached({ timeout: 10000 });
 	await setToggleChecked(deleteConfirmToggle, true);
 	await takeStepScreenshot(page, 'delete-account-confirmed');
 	logSignupCheckpoint('Confirmed delete account data warning.');
@@ -343,7 +343,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	// Click delete button — should open the auth modal with email OTP (not 2FA).
 	await page.getByTestId('delete-account-container').getByTestId('delete-button').click();
 	const authModal = page.getByTestId('auth-modal');
-	await expect(authModal).toBeVisible({ timeout: 15000 });
+	await expect(authModal).toBeVisible({ timeout: 10000 });
 	await takeStepScreenshot(page, 'delete-account-auth-email-otp');
 
 	// Verify this is the email OTP flow (not 2FA or passkey).
@@ -365,7 +365,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	// The backend may fail with "Failed to retrieve email" if encryption keys aren't
 	// synced yet for the freshly created account. Retry once after a short wait.
 	const deleteOtpInput = emailOtpSection.locator('input[inputmode="numeric"]');
-	const otpVisible = await deleteOtpInput.isVisible({ timeout: 10000 }).catch(() => false);
+	const otpVisible = await deleteOtpInput.isVisible({ timeout: 5000 }).catch(() => false);
 	if (!otpVisible) {
 		const errorText = await page.getByText(/failed to retrieve email/i).isVisible({ timeout: 2000 }).catch(() => false);
 		if (errorText) {
@@ -374,7 +374,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 			await sendCodeButton.click();
 		}
 	}
-	await expect(deleteOtpInput).toBeVisible({ timeout: 30000 });
+	await expect(deleteOtpInput).toBeVisible({ timeout: 10000 });
 	await takeStepScreenshot(page, 'delete-account-otp-input');
 
 	// Get the verification code from Mailosaur email.
@@ -397,7 +397,7 @@ test('completes signup with skipped 2FA, login with password, and delete account
 	// The deletion flow sets a brief success message then navigates away,
 	// so we wait for the redirect rather than the transient success message.
 	await page.waitForFunction(() => window.location.hash.includes('demo-for-everyone'), null, {
-		timeout: 60000
+		timeout: 10000
 	});
 	await takeStepScreenshot(page, 'delete-account-redirected');
 	logSignupCheckpoint('Account deleted and redirected to demo chat.');

--- a/frontend/packages/ui/src/components/ActiveChat.svelte
+++ b/frontend/packages/ui/src/components/ActiveChat.svelte
@@ -6468,6 +6468,26 @@ console.debug('[ActiveChat] Loading child website embeds for web search fullscre
             // SAFETY NET: messagesUpdated flag is set (e.g. by batch sync) but no inline
             // messages were provided in the event.  Reload from IndexedDB so the display
             // never goes stale after a sync writes new/updated messages to the DB.
+            //
+            // Guard: skip IDB reload if in-flight messages are active (demo→real conversion).
+            // The IDB contains demo history alongside the new message — reloading would cause
+            // demo messages to bleed into the real conversation. The streaming path will handle
+            // message updates until all messages settle to 'synced'.
+            const hasActiveInFlight = currentMessages.some(m =>
+                m.chat_id === currentChat?.chat_id && (
+                    m.status === 'streaming' ||
+                    m.status === 'sending' ||
+                    m.status === 'processing'
+                )
+            );
+            if (hasActiveInFlight) {
+                console.debug(`[ActiveChat] handleChatUpdated: messagesUpdated=true but ${currentMessages.filter(m => m.status === 'streaming' || m.status === 'sending' || m.status === 'processing').length} in-flight message(s) present — skipping IDB reload to prevent demo history bleed-through.`);
+                // Still update chat metadata if provided
+                if (detail.chat) {
+                    currentChat = { ...currentChat, ...detail.chat } as typeof currentChat;
+                }
+                return;
+            }
             console.debug('[ActiveChat] handleChatUpdated: messagesUpdated=true but no messages in event. Reloading from IndexedDB for chat:', currentChat.chat_id);
             try {
                 const freshMessages: ChatMessageModel[] = await chatDB.getMessagesForChat(currentChat.chat_id);
@@ -7058,25 +7078,26 @@ console.debug('[ActiveChat] Loading child website embeds for web search fullscre
         if (isReloadingSameChat && existingInFlightMessages.length > 0) {
             console.debug(`[ActiveChat] loadChat: Preserving ${existingInFlightMessages.length} in-flight message(s) during reload of same chat ${chat.chat_id} (statuses: ${existingInFlightMessages.map(m => m.status).join(', ')})`);
             
-            // CRITICAL: If currentMessages consists ONLY of in-flight messages for this chat, it means
-            // handleSendMessage just initialised the view (e.g. after converting a demo chat to a real
-            // chat).  At this point sendHandlers has already copied the demo history into IndexedDB so
-            // any DB read would return demo messages + the new user message — making them appear as
-            // "follow-up" messages to the demo conversation in the UI.
+            // CRITICAL: If currentMessages were set by handleSendMessage (demo→real chat conversion),
+            // skip the DB reload. The DB now contains demo history messages alongside the new user
+            // message, which would cause demo messages to bleed into the real conversation UI.
             //
-            // In this case we skip the DB reload entirely: the in-memory currentMessages set by
-            // handleSendMessage is already correct (only the new user message), and subsequent server
-            // events (ai_response_storage_confirmed, chatUpdated with newMessage, etc.) will append
-            // the AI reply through the normal streaming path.  On reload the DB is the source of
-            // truth and loadChat is called with a clean slate, which is correct behaviour.
-            const allCurrentMessagesAreInFlight = currentMessages.length > 0 &&
-                currentMessages.every(m => m.chat_id === chat.chat_id && (
-                    m.status === 'streaming' ||
-                    m.status === 'sending' ||
-                    m.status === 'processing'
-                ));
-            if (allCurrentMessagesAreInFlight) {
-                console.info(`[ActiveChat] loadChat: currentMessages contains ONLY in-flight message(s) for ${chat.chat_id} — skipping DB reload to prevent demo history bleed-through. Keeping handleSendMessage-initialised view.`);
+            // Detection: currentMessages has only messages for THIS chat and at least one is still
+            // in-flight (streaming/sending/processing). The original guard only fired when ALL messages
+            // were in-flight, but after chat_message_confirmed the user message transitions to 'synced'
+            // while the AI message is still 'streaming' — broadened to catch that race too.
+            const allMessagesForThisChat = currentMessages.length > 0 &&
+                currentMessages.every(m => m.chat_id === chat.chat_id);
+            const hasAnyInFlight = currentMessages.some(m =>
+                m.status === 'streaming' ||
+                m.status === 'sending' ||
+                m.status === 'processing'
+            );
+            // Only skip DB reload when messages are exclusively for this chat AND at least one
+            // is still in-flight (the conversation is actively being created/streamed). This
+            // prevents demo history bleed-through while allowing normal reloads of settled chats.
+            if (allMessagesForThisChat && hasAnyInFlight) {
+                console.info(`[ActiveChat] loadChat: currentMessages for ${chat.chat_id} has in-flight message(s) — skipping DB reload to prevent demo history bleed-through. Keeping handleSendMessage-initialised view.`);
                 // Return early — skip currentMessages = newMessages below.
                 // We still need to update currentChat metadata so the header/title are correct.
                 currentChat = freshChat ?? chat;

--- a/frontend/packages/ui/src/components/ChatHeader.svelte
+++ b/frontend/packages/ui/src/components/ChatHeader.svelte
@@ -366,7 +366,7 @@
     <div class="loaded-content">
       <!-- Category icon (38×38px) -->
       {#if IconComponent}
-        <div class="loaded-icon">
+        <div class="loaded-icon" data-testid="chat-header-icon">
           <IconComponent size={38} color="white" />
         </div>
       {/if}
@@ -384,7 +384,7 @@
 
       <!-- Summary: fades in with max-height expand when available -->
       {#if showSummary}
-        <p class="loaded-summary">{summary}</p>
+        <p class="loaded-summary" data-testid="chat-header-summary">{summary}</p>
       {/if}
 
       <!-- Creation time -->

--- a/frontend/packages/ui/src/components/embeds/health/HealthAppointmentEmbedFullscreen.svelte
+++ b/frontend/packages/ui/src/components/embeds/health/HealthAppointmentEmbedFullscreen.svelte
@@ -187,20 +187,12 @@
     }
   }
 
-  /** Map accessibility flag keys to short German/English labels. */
+  /** Map accessibility flag keys to translated labels. */
   function accessibilityLabel(flag: string): string {
-    switch (flag) {
-      case 'wheelchair_entrance':
-        return 'Wheelchair entrance';
-      case 'wheelchair_parking':
-        return 'Wheelchair parking';
-      case 'wheelchair_seating':
-        return 'Wheelchair seating';
-      case 'wheelchair_restroom':
-        return 'Wheelchair restroom';
-      default:
-        return flag;
-    }
+    const key = `embeds.health.${flag}`;
+    const translated = $text(key);
+    // If the key isn't found, $text returns the key itself — fall back to the raw flag
+    return translated !== key ? translated : flag;
   }
 
   function getAddressLines(value: unknown): string[] {
@@ -250,7 +242,7 @@
   /** Header title: formatted appointment date/time (most important info at a glance) */
   let headerTitle = $derived.by(() => {
     if (effectiveSlotDatetime) return formatSlot(effectiveSlotDatetime);
-    return activeAppointment?.name || activeAppointment?.speciality || 'Appointment';
+    return activeAppointment?.name || activeAppointment?.speciality || $text('embeds.health.appointment');
   });
 
   /** Header subtitle: doctor name + speciality (secondary context) */
@@ -332,10 +324,10 @@
         <span class="badge telehealth-badge">{$text('embeds.health.telehealth')}</span>
       {/if}
       {#if activeAppointment.insurance === 'unknown'}
-        <!-- Jameda doesn't expose per-doctor insurance sector info — warn
-             the user that they need to verify it on Jameda before booking -->
-        <span class="badge insurance-unknown-badge" title="Insurance requirement not available — verify on Jameda before booking">
-          Insurance: verify on Jameda
+        <!-- Some providers don't expose per-doctor insurance sector info — warn
+             the user that they need to verify it on the provider before booking -->
+        <span class="badge insurance-unknown-badge" title={$text('embeds.health.insurance_verify_tooltip').replace('{provider}', providerName)}>
+          {$text('embeds.health.insurance_verify_on_provider').replace('{provider}', providerName)}
         </span>
       {:else if activeAppointment.insurance}
         <span class="badge insurance-badge">{activeAppointment.insurance}</span>
@@ -350,7 +342,7 @@
     <!-- Alternate slot times for the same doctor (from _group_slots_by_doctor) -->
     {#if activeAppointment.additional_slot_datetimes && activeAppointment.additional_slot_datetimes.length > 0}
       <div class="alternate-slots">
-        <div class="section-title">Also available</div>
+        <div class="section-title">{$text('embeds.health.also_available')}</div>
         <div class="alternate-slots-list">
           {#each activeAppointment.additional_slot_datetimes as altIso}
             <span class="alternate-slot">{formatAlternateSlot(altIso)}</span>
@@ -367,7 +359,7 @@
     <!-- Opening hours from Google Places -->
     {#if activeAppointment.opening_hours && activeAppointment.opening_hours.length > 0}
       <div class="opening-hours">
-        <div class="section-title">Opening hours</div>
+        <div class="section-title">{$text('embeds.health.opening_hours')}</div>
         <ul class="opening-hours-list">
           {#each activeAppointment.opening_hours as line}
             <li>{line}</li>
@@ -379,7 +371,7 @@
     <!-- Patient reviews from Google Places (up to 5) -->
     {#if activeAppointment.google_reviews && activeAppointment.google_reviews.length > 0}
       <div class="reviews">
-        <div class="section-title">Patient reviews</div>
+        <div class="section-title">{$text('embeds.health.patient_reviews')}</div>
         {#each activeAppointment.google_reviews as review}
           <div class="review-card">
             <div class="review-header">
@@ -408,10 +400,10 @@
           <a class="external-link" href={`tel:${activeAppointment.phone}`}>{activeAppointment.phone}</a>
         {/if}
         {#if activeAppointment.website}
-          <a class="external-link" href={activeAppointment.website} target="_blank" rel="noopener noreferrer">Website</a>
+          <a class="external-link" href={activeAppointment.website} target="_blank" rel="noopener noreferrer">{$text('embeds.health.website')}</a>
         {/if}
         {#if activeAppointment.google_maps_uri}
-          <a class="external-link" href={activeAppointment.google_maps_uri} target="_blank" rel="noopener noreferrer">View on Google Maps</a>
+          <a class="external-link" href={activeAppointment.google_maps_uri} target="_blank" rel="noopener noreferrer">{$text('embeds.health.view_on_google_maps')}</a>
         {/if}
       </div>
     {/if}

--- a/frontend/packages/ui/src/components/settings/SettingsMainHeader.svelte
+++ b/frontend/packages/ui/src/components/settings/SettingsMainHeader.svelte
@@ -197,7 +197,7 @@
                         aria-label={$text('settings.billing')}
                     >
                         <span class="credits-coin-icon" class:credits-coin-icon-collapsed={isCollapsed}></span>
-                        <span class="credits-amount" class:credits-amount-collapsed={isCollapsed}>{$text('settings.credits_amount').replace('{credits_amount}', formattedCredits)}</span>
+                        <span class="credits-amount" class:credits-amount-collapsed={isCollapsed} data-testid="credits-amount">{$text('settings.credits_amount').replace('{credits_amount}', formattedCredits)}</span>
                     </button>
                 </div>
             {/if}

--- a/frontend/packages/ui/src/components/signup/steps/confirmemail/ConfirmEmailBottomContent.svelte
+++ b/frontend/packages/ui/src/components/signup/steps/confirmemail/ConfirmEmailBottomContent.svelte
@@ -25,59 +25,110 @@
         }
     });
 
+    /** Maximum number of verification attempts for transient "code not found" errors. */
+    const MAX_VERIFY_ATTEMPTS = 3;
+    /** Delay (ms) between retry attempts — gives the Celery email task time to
+     *  finish writing the verification code to cache. */
+    const VERIFY_RETRY_DELAY_MS = 2000;
+
+    /**
+     * Verify the email confirmation code against the backend.
+     *
+     * Architecture note: The signup flow dispatches a Celery task to generate
+     * the code, store it in Redis, and send the email. Because the API returns
+     * "success" *before* the Celery task completes, there is a short window
+     * where the code is not yet in cache. If the user (or a Playwright test)
+     * enters the code very quickly, the verification can fail with
+     * "No verification code requested for this email or code expired."
+     *
+     * To handle this race condition we retry up to MAX_VERIFY_ATTEMPTS times
+     * with a short delay, but ONLY for that specific transient error. Wrong
+     * codes and other errors surface immediately without retry.
+     */
     async function verifyCode(code: string) {
         if (isVerifying) return; // Prevent re-execution if already verifying
         if (code.length !== 6) return;
-        
-        try {
-            isVerifying = true;
-            errorMessage = '';
-            showError = false;
 
-            const storeData = get(signupStore);
-            
-            const response = await fetch(getApiEndpoint(apiEndpoints.auth.check_confirm_email_code), {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    code: code,
-                    email: storeData.email,
-                    username: storeData.username,
-                    invite_code: storeData.inviteCode,
-                    language: storeData.language,
-                    darkmode: storeData.darkmode
-                }),
-                credentials: 'include'
-            });
-            
-            const data = await response.json();
-            
-            if (response.ok && data.success) {
-                // In the new architecture, email verification doesn't create a user yet
-                // It just verifies the email and stores verification status in cache
-                
-                // Make sure we stay in signup flow and move to secure account step
-                currentSignupStep.set('secure_account');
-                isInSignupProcess.set(true);
-                
-                // Proceed to next step on success
-                dispatch('step', { step: 'secure_account' });
-            } else {
-                // Show error message
+        isVerifying = true;
+        errorMessage = '';
+        showError = false;
+
+        const storeData = get(signupStore);
+
+        for (let attempt = 1; attempt <= MAX_VERIFY_ATTEMPTS; attempt++) {
+            try {
+                const response = await fetch(getApiEndpoint(apiEndpoints.auth.check_confirm_email_code), {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        code: code,
+                        email: storeData.email,
+                        username: storeData.username,
+                        invite_code: storeData.inviteCode,
+                        language: storeData.language,
+                        darkmode: storeData.darkmode
+                    }),
+                    credentials: 'include'
+                });
+
+                const data = await response.json();
+
+                if (response.ok && data.success) {
+                    // In the new architecture, email verification doesn't create a user yet
+                    // It just verifies the email and stores verification status in cache
+
+                    // Make sure we stay in signup flow and move to secure account step
+                    currentSignupStep.set('secure_account');
+                    isInSignupProcess.set(true);
+
+                    // Proceed to next step on success
+                    dispatch('step', { step: 'secure_account' });
+                    isVerifying = false;
+                    return;
+                }
+
+                // Transient "code not yet in cache" error — retry after a short delay.
+                // The Celery task that stores the code may still be in flight.
+                const isCodeNotFound = typeof data.message === 'string' &&
+                    data.message.toLowerCase().includes('no verification code');
+
+                if (isCodeNotFound && attempt < MAX_VERIFY_ATTEMPTS) {
+                    console.debug(
+                        `[ConfirmEmail] Code not in cache yet (attempt ${attempt}/${MAX_VERIFY_ATTEMPTS}), retrying in ${VERIFY_RETRY_DELAY_MS}ms...`
+                    );
+                    await new Promise(resolve => setTimeout(resolve, VERIFY_RETRY_DELAY_MS));
+                    continue;
+                }
+
+                // Final attempt or non-transient error — show to user
                 errorMessage = data.message || 'Invalid verification code. Please try again.';
                 showError = true;
                 otpCode = ''; // Clear the input
+                isVerifying = false;
+                return;
+            } catch (error) {
+                console.error('Error verifying code:', error);
+
+                // Network errors on non-final attempts get a retry
+                if (attempt < MAX_VERIFY_ATTEMPTS) {
+                    console.debug(
+                        `[ConfirmEmail] Network error (attempt ${attempt}/${MAX_VERIFY_ATTEMPTS}), retrying in ${VERIFY_RETRY_DELAY_MS}ms...`
+                    );
+                    await new Promise(resolve => setTimeout(resolve, VERIFY_RETRY_DELAY_MS));
+                    continue;
+                }
+
+                errorMessage = 'Error verifying code. Please try again.';
+                showError = true;
+                otpCode = ''; // Clear the input
+                isVerifying = false;
+                return;
             }
-        } catch (error) {
-            console.error('Error verifying code:', error);
-            errorMessage = 'Error verifying code. Please try again.';
-            showError = true;
-            otpCode = ''; // Clear the input
-        } finally {
-            isVerifying = false;
         }
+
+        isVerifying = false;
     }
 
     function handleInput(event: Event) {

--- a/frontend/packages/ui/src/demo_chats/convertToChat.ts
+++ b/frontend/packages/ui/src/demo_chats/convertToChat.ts
@@ -54,7 +54,7 @@ export function convertDemoMessagesToMessages(demoMessages: DemoMessage[], chatI
 		// CLEARTEXT fields - demo messages are already decrypted server-side
 		content: demoMsg.content,
 		category: demoMsg.role === 'assistant' ? category : undefined,
-		created_at: new Date(demoMsg.timestamp).getTime(),
+		created_at: Math.floor(new Date(demoMsg.timestamp).getTime() / 1000),
 		status: 'synced' as const // Demo messages are always synced
 	}));
 }

--- a/frontend/packages/ui/src/i18n/sources/embeds.yml
+++ b/frontend/packages/ui/src/i18n/sources/embeds.yml
@@ -3656,6 +3656,306 @@ health.reviews:
   he: ביקורות
   verified_by_human: []
 
+health.insurance_verify_on_provider:
+  context: Badge text shown when insurance info is unknown for a doctor. {provider} is the booking platform name (e.g. Doctolib, Jameda).
+  en: "Insurance: verify on {provider}"
+  de: "Versicherung: auf {provider} prüfen"
+  zh: 保险：请在{provider}上核实
+  es: "Seguro: verificar en {provider}"
+  fr: "Assurance : vérifier sur {provider}"
+  pt: "Seguro: verificar no {provider}"
+  ru: "Страховка: уточните на {provider}"
+  ja: "保険：{provider}で確認"
+  ko: "보험: {provider}에서 확인"
+  it: "Assicurazione: verifica su {provider}"
+  tr: "Sigorta: {provider} üzerinden doğrulayın"
+  vi: "Bảo hiểm: xác minh trên {provider}"
+  id: "Asuransi: verifikasi di {provider}"
+  pl: "Ubezpieczenie: sprawdź na {provider}"
+  nl: "Verzekering: controleer op {provider}"
+  ar: "التأمين: تحقق على {provider}"
+  hi: "बीमा: {provider} पर सत्यापित करें"
+  th: "ประกัน: ตรวจสอบบน {provider}"
+  cs: "Pojištění: ověřte na {provider}"
+  sv: "Försäkring: verifiera på {provider}"
+  he: "ביטוח: בדוק ב-{provider}"
+  verified_by_human: []
+
+health.insurance_verify_tooltip:
+  context: Tooltip for the insurance-unknown badge. {provider} is the booking platform name.
+  en: Insurance requirement not available — verify on {provider} before booking
+  de: Versicherungsinformation nicht verfügbar — vor der Buchung auf {provider} prüfen
+  zh: 保险要求不可用——预约前请在{provider}上核实
+  es: Requisito de seguro no disponible — verificar en {provider} antes de reservar
+  fr: Information d'assurance non disponible — vérifier sur {provider} avant de réserver
+  pt: Requisito de seguro não disponível — verificar no {provider} antes de agendar
+  ru: Информация о страховке недоступна — проверьте на {provider} перед записью
+  ja: 保険情報なし — 予約前に{provider}でご確認ください
+  ko: 보험 정보 없음 — 예약 전 {provider}에서 확인하세요
+  it: Requisito assicurativo non disponibile — verificare su {provider} prima della prenotazione
+  tr: Sigorta bilgisi mevcut değil — rezervasyon öncesi {provider} üzerinden doğrulayın
+  vi: Yêu cầu bảo hiểm không có sẵn — xác minh trên {provider} trước khi đặt lịch
+  id: Persyaratan asuransi tidak tersedia — verifikasi di {provider} sebelum memesan
+  pl: Informacja o ubezpieczeniu niedostępna — sprawdź na {provider} przed rezerwacją
+  nl: Verzekeringsvereiste niet beschikbaar — controleer op {provider} voor het boeken
+  ar: متطلبات التأمين غير متوفرة — تحقق على {provider} قبل الحجز
+  hi: बीमा आवश्यकता उपलब्ध नहीं — बुकिंग से पहले {provider} पर सत्यापित करें
+  th: ข้อมูลประกันไม่พร้อมใช้งาน — ตรวจสอบบน {provider} ก่อนจอง
+  cs: Informace o pojištění nejsou k dispozici — před rezervací ověřte na {provider}
+  sv: Försäkringskrav ej tillgängligt — verifiera på {provider} före bokning
+  he: דרישת ביטוח לא זמינה — בדוק ב-{provider} לפני הזמנה
+  verified_by_human: []
+
+health.also_available:
+  context: Section title for alternate appointment time slots for the same doctor
+  en: Also available
+  de: Auch verfügbar
+  zh: 其他可用时间
+  es: También disponible
+  fr: Également disponible
+  pt: Também disponível
+  ru: Также доступно
+  ja: 他の空き時間
+  ko: 다른 가능한 시간
+  it: Anche disponibile
+  tr: Ayrıca müsait
+  vi: Cũng có sẵn
+  id: Juga tersedia
+  pl: Również dostępne
+  nl: Ook beschikbaar
+  ar: متاح أيضاً
+  hi: अन्य उपलब्ध समय
+  th: เวลาอื่นที่ว่าง
+  cs: Také k dispozici
+  sv: Även tillgänglig
+  he: זמין גם
+  verified_by_human: []
+
+health.opening_hours:
+  context: Section title for practice opening hours from Google Places
+  en: Opening hours
+  de: Öffnungszeiten
+  zh: 营业时间
+  es: Horario de apertura
+  fr: Horaires d'ouverture
+  pt: Horário de funcionamento
+  ru: Часы работы
+  ja: 診療時間
+  ko: 진료 시간
+  it: Orari di apertura
+  tr: Çalışma saatleri
+  vi: Giờ mở cửa
+  id: Jam buka
+  pl: Godziny otwarcia
+  nl: Openingstijden
+  ar: ساعات العمل
+  hi: खुलने का समय
+  th: เวลาทำการ
+  cs: Otevírací doba
+  sv: Öppettider
+  he: שעות פתיחה
+  verified_by_human: []
+
+health.patient_reviews:
+  context: Section title for patient reviews from Google Places
+  en: Patient reviews
+  de: Patientenbewertungen
+  zh: 患者评价
+  es: Opiniones de pacientes
+  fr: Avis de patients
+  pt: Avaliações de pacientes
+  ru: Отзывы пациентов
+  ja: 患者レビュー
+  ko: 환자 리뷰
+  it: Recensioni dei pazienti
+  tr: Hasta yorumları
+  vi: Đánh giá bệnh nhân
+  id: Ulasan pasien
+  pl: Opinie pacjentów
+  nl: Patiëntbeoordelingen
+  ar: تقييمات المرضى
+  hi: रोगी समीक्षाएं
+  th: รีวิวจากผู้ป่วย
+  cs: Hodnocení pacientů
+  sv: Patientomdömen
+  he: ביקורות מטופלים
+  verified_by_human: []
+
+health.website:
+  context: Link label for a doctor's website
+  en: Website
+  de: Webseite
+  zh: 网站
+  es: Sitio web
+  fr: Site web
+  pt: Site
+  ru: Сайт
+  ja: ウェブサイト
+  ko: 웹사이트
+  it: Sito web
+  tr: Web sitesi
+  vi: Trang web
+  id: Situs web
+  pl: Strona internetowa
+  nl: Website
+  ar: الموقع الإلكتروني
+  hi: वेबसाइट
+  th: เว็บไซต์
+  cs: Webové stránky
+  sv: Webbplats
+  he: אתר אינטרנט
+  verified_by_human: []
+
+health.view_on_google_maps:
+  context: Link label to open the practice location in Google Maps
+  en: View on Google Maps
+  de: In Google Maps ansehen
+  zh: 在Google地图查看
+  es: Ver en Google Maps
+  fr: Voir sur Google Maps
+  pt: Ver no Google Maps
+  ru: Посмотреть на Google Maps
+  ja: Google マップで見る
+  ko: Google 지도에서 보기
+  it: Vedi su Google Maps
+  tr: Google Haritalar'da görüntüle
+  vi: Xem trên Google Maps
+  id: Lihat di Google Maps
+  pl: Zobacz w Mapach Google
+  nl: Bekijken op Google Maps
+  ar: عرض على خرائط Google
+  hi: Google Maps पर देखें
+  th: ดูบน Google Maps
+  cs: Zobrazit na Google Maps
+  sv: Visa på Google Maps
+  he: הצג ב-Google Maps
+  verified_by_human: []
+
+health.appointment:
+  context: Fallback header title when no appointment datetime or doctor name is available
+  en: Appointment
+  de: Termin
+  zh: 预约
+  es: Cita
+  fr: Rendez-vous
+  pt: Consulta
+  ru: Запись
+  ja: 予約
+  ko: 예약
+  it: Appuntamento
+  tr: Randevu
+  vi: Lịch hẹn
+  id: Janji temu
+  pl: Wizyta
+  nl: Afspraak
+  ar: موعد
+  hi: अपॉइंटमेंट
+  th: นัดหมาย
+  cs: Schůzka
+  sv: Bokad tid
+  he: תור
+  verified_by_human: []
+
+health.wheelchair_entrance:
+  context: Accessibility badge — practice has wheelchair-accessible entrance
+  en: Wheelchair entrance
+  de: Rollstuhlgerechter Eingang
+  zh: 轮椅入口
+  es: Entrada para sillas de ruedas
+  fr: Entrée accessible en fauteuil roulant
+  pt: Entrada para cadeira de rodas
+  ru: Вход для инвалидных колясок
+  ja: 車椅子対応入口
+  ko: 휠체어 입구
+  it: Ingresso per sedie a rotelle
+  tr: Tekerlekli sandalye girişi
+  vi: Lối vào xe lăn
+  id: Akses masuk kursi roda
+  pl: Wejście dla wózków inwalidzkich
+  nl: Rolstoeltoegankelijke ingang
+  ar: مدخل كراسي متحركة
+  hi: व्हीलचेयर प्रवेश
+  th: ทางเข้าสำหรับรถเข็น
+  cs: Bezbariérový vchod
+  sv: Rullstolsanpassad ingång
+  he: כניסה לכיסא גלגלים
+  verified_by_human: []
+
+health.wheelchair_parking:
+  context: Accessibility badge — practice has wheelchair-accessible parking
+  en: Wheelchair parking
+  de: Rollstuhlgerechter Parkplatz
+  zh: 轮椅停车位
+  es: Estacionamiento para sillas de ruedas
+  fr: Parking accessible en fauteuil roulant
+  pt: Estacionamento para cadeira de rodas
+  ru: Парковка для инвалидных колясок
+  ja: 車椅子対応駐車場
+  ko: 휠체어 주차
+  it: Parcheggio per sedie a rotelle
+  tr: Tekerlekli sandalye parkı
+  vi: Bãi đỗ xe lăn
+  id: Parkir kursi roda
+  pl: Parking dla wózków inwalidzkich
+  nl: Rolstoeltoegankelijke parkeerplaats
+  ar: موقف كراسي متحركة
+  hi: व्हीलचेयर पार्किंग
+  th: ที่จอดรถเข็น
+  cs: Bezbariérové parkování
+  sv: Rullstolsanpassad parkering
+  he: חניה לכיסא גלגלים
+  verified_by_human: []
+
+health.wheelchair_seating:
+  context: Accessibility badge — practice has wheelchair-accessible seating
+  en: Wheelchair seating
+  de: Rollstuhlgerechte Sitzplätze
+  zh: 轮椅座位
+  es: Asientos para sillas de ruedas
+  fr: Places assises accessibles en fauteuil roulant
+  pt: Assentos para cadeira de rodas
+  ru: Места для инвалидных колясок
+  ja: 車椅子対応座席
+  ko: 휠체어 좌석
+  it: Posti a sedere per sedie a rotelle
+  tr: Tekerlekli sandalye oturma alanı
+  vi: Chỗ ngồi xe lăn
+  id: Tempat duduk kursi roda
+  pl: Miejsca dla wózków inwalidzkich
+  nl: Rolstoeltoegankelijke zitplaatsen
+  ar: مقاعد كراسي متحركة
+  hi: व्हीलचेयर बैठक
+  th: ที่นั่งสำหรับรถเข็น
+  cs: Bezbariérové sezení
+  sv: Rullstolsanpassade sittplatser
+  he: ישיבה לכיסא גלגלים
+  verified_by_human: []
+
+health.wheelchair_restroom:
+  context: Accessibility badge — practice has wheelchair-accessible restroom
+  en: Wheelchair restroom
+  de: Rollstuhlgerechte Toilette
+  zh: 轮椅卫生间
+  es: Baño para sillas de ruedas
+  fr: Toilettes accessibles en fauteuil roulant
+  pt: Banheiro para cadeira de rodas
+  ru: Туалет для инвалидных колясок
+  ja: 車椅子対応トイレ
+  ko: 휠체어 화장실
+  it: Bagno per sedie a rotelle
+  tr: Tekerlekli sandalye tuvaleti
+  vi: Phòng vệ sinh xe lăn
+  id: Toilet kursi roda
+  pl: Toaleta dla wózków inwalidzkich
+  nl: Rolstoeltoegankelijk toilet
+  ar: دورة مياه كراسي متحركة
+  hi: व्हीलचेयर शौचालय
+  th: ห้องน้ำสำหรับรถเข็น
+  cs: Bezbariérové toalety
+  sv: Rullstolsanpassad toalett
+  he: שירותים לכיסא גלגלים
+  verified_by_human: []
+
 shopping.product:
   context: Singular label for a shopping product result
   en: product

--- a/frontend/packages/ui/src/services/chatSyncServiceHandlersChatUpdates.ts
+++ b/frontend/packages/ui/src/services/chatSyncServiceHandlersChatUpdates.ts
@@ -247,7 +247,7 @@ export async function handleChatDraftUpdatedImpl(
         updated_at: payload.last_edited_overall_timestamp,
       };
       // Use a separate transaction for addChat (it will create its own internally)
-      await chatDB.addChat(newChatForDraft);
+      await chatDB.addChat(newChatForDraft, undefined, { isFromSync: true });
     }
 
     // DB operations completed successfully - now do cache invalidation and event dispatch
@@ -549,7 +549,7 @@ export async function handleNewChatMessageImpl(
         );
       }
 
-      await chatDB.addChat(newChat);
+      await chatDB.addChat(newChat, undefined, { isFromSync: true });
       chat = newChat; // Use the newly created chat for message saving
       console.info(
         `[ChatSyncService:ChatUpdates] Created new chat shell ${payload.chat_id} successfully`,

--- a/frontend/packages/ui/src/services/chatSyncServiceHandlersCoreSync.ts
+++ b/frontend/packages/ui/src/services/chatSyncServiceHandlersCoreSync.ts
@@ -312,7 +312,7 @@ export async function handlePhase1LastChatImpl(
         id: payload.chat_id,
       } as Partial<Chat> & { id: string });
       allPhase1Chats.push(lastChat);
-      await chatDB.addChat(lastChat);
+      await chatDB.addChat(lastChat, undefined, { isFromSync: true });
       chatListCache.upsertChat(lastChat);
     }
 
@@ -320,7 +320,7 @@ export async function handlePhase1LastChatImpl(
       for (const meta of payload.recent_chat_metadata) {
         const chat = buildChat(meta);
         allPhase1Chats.push(chat);
-        await chatDB.addChat(chat);
+        await chatDB.addChat(chat, undefined, { isFromSync: true });
         chatListCache.upsertChat(chat);
       }
     }
@@ -527,7 +527,7 @@ export async function handlePhase1bChatContentImpl(
             chatData.server_message_count,
           );
           if (updatedV > (existingChat.messages_v || 0)) {
-            await chatDB.addChat({ ...existingChat, messages_v: updatedV });
+            await chatDB.addChat({ ...existingChat, messages_v: updatedV }, undefined, { isFromSync: true });
           }
         }
       }

--- a/frontend/packages/ui/src/services/chatSyncServiceHandlersPhasedSync.ts
+++ b/frontend/packages/ui/src/services/chatSyncServiceHandlersPhasedSync.ts
@@ -370,7 +370,7 @@ export async function handleBackgroundMessageSyncImpl(
           chatData.messages_v || chatData.server_message_count || 0,
         );
         if (newV > (existingChat.messages_v || 0)) {
-          await chatDB.addChat({ ...existingChat, messages_v: newV });
+          await chatDB.addChat({ ...existingChat, messages_v: newV }, undefined, { isFromSync: true });
         }
       }
     }
@@ -563,7 +563,7 @@ async function storeRecentChats(
 
       // Metadata-only path: save chat and move on (no message processing)
       if (!shouldSyncMessages) {
-        await chatDB.addChat(mergedChat);
+        await chatDB.addChat(mergedChat, undefined, { isFromSync: true });
         chatListCache.upsertChat(mergedChat);
         processedChatIds.add(chatId);
         continue;
@@ -583,7 +583,7 @@ async function storeRecentChats(
       }
 
       if (shouldSkipMessageSync) {
-        await chatDB.addChat(mergedChat);
+        await chatDB.addChat(mergedChat, undefined, { isFromSync: true });
         chatListCache.upsertChat(mergedChat);
         processedChatIds.add(chatId);
         continue;
@@ -598,7 +598,7 @@ async function storeRecentChats(
 
       // Save chat and messages
       try {
-        await chatDB.addChat(mergedChat);
+        await chatDB.addChat(mergedChat, undefined, { isFromSync: true });
         chatListCache.upsertChat(mergedChat);
 
         if (shouldSyncMessages && preparedMessages.length > 0) {
@@ -747,7 +747,7 @@ async function storeAllChats(
             ...mergedChat,
             messages_v: 0, // Reset to force re-sync on next load
           };
-          await chatDB.addChat(mergedChat);
+          await chatDB.addChat(mergedChat, undefined, { isFromSync: true });
           chatListCache.upsertChat(mergedChat);
 
           // Dispatch event to notify about the inconsistency
@@ -786,14 +786,14 @@ async function storeAllChats(
       }
 
       if (shouldSkipMessageSync) {
-        await chatDB.addChat(mergedChat);
+        await chatDB.addChat(mergedChat, undefined, { isFromSync: true });
         chatListCache.upsertChat(mergedChat);
         continue;
       }
 
       // Save chat and messages
       try {
-        await chatDB.addChat(mergedChat);
+        await chatDB.addChat(mergedChat, undefined, { isFromSync: true });
         chatListCache.upsertChat(mergedChat);
 
         if (shouldSyncMessages && messages && messages.length > 0) {

--- a/frontend/packages/ui/src/services/db.ts
+++ b/frontend/packages/ui/src/services/db.ts
@@ -1115,8 +1115,8 @@ class ChatDatabase {
   // CHAT CRUD OPERATIONS (delegated to chatCrudOperations.ts)
   // ============================================================================
 
-  async addChat(chat: Chat, transaction?: IDBTransaction): Promise<void> {
-    return chatCrudOps.addChat(this, chat, transaction);
+  async addChat(chat: Chat, transaction?: IDBTransaction, options?: { isFromSync?: boolean }): Promise<void> {
+    return chatCrudOps.addChat(this, chat, transaction, options);
   }
 
   async getAllChats(

--- a/frontend/packages/ui/src/services/db/__tests__/encryptChatForStorage.test.ts
+++ b/frontend/packages/ui/src/services/db/__tests__/encryptChatForStorage.test.ts
@@ -1,0 +1,247 @@
+// frontend/packages/ui/src/services/db/__tests__/encryptChatForStorage.test.ts
+// Tests for the isFromSync guard in encryptChatForStorage.
+//
+// Root cause this guards against:
+//  - During phased sync after logout/login, encryptChatForStorage was called
+//    for existing chats with no available key. It fell through to
+//    createKeyForNewChat(), generating a NEW random key that overwrote the
+//    original, making all existing messages permanently undecryptable.
+//
+// The fix: when isFromSync=true, Step 4 (key creation) is skipped and the
+// chat is stored without a key. The correct key arrives later via
+// receiveKeyFromServer().
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+// Mock cryptoService
+const mockDecryptChatKeyWithMasterKey = vi.fn();
+const mockEncryptChatKeyWithMasterKey = vi.fn();
+vi.mock("../../cryptoService", () => ({
+  encryptChatKeyWithMasterKey: (...args: unknown[]) =>
+    mockEncryptChatKeyWithMasterKey(...args),
+  decryptChatKeyWithMasterKey: (...args: unknown[]) =>
+    mockDecryptChatKeyWithMasterKey(...args),
+}));
+
+// Mock ChatKeyManager
+const mockGetKeySync = vi.fn();
+const mockInjectKey = vi.fn();
+const mockCreateKeyForNewChat = vi.fn();
+const mockComputeKeyFingerprint = vi.fn().mockReturnValue("abcd1234");
+vi.mock("../../encryption/ChatKeyManager", () => ({
+  chatKeyManager: {
+    getKeySync: (...args: unknown[]) => mockGetKeySync(...args),
+    injectKey: (...args: unknown[]) => mockInjectKey(...args),
+    createKeyForNewChat: (...args: unknown[]) => mockCreateKeyForNewChat(...args),
+  },
+  computeKeyFingerprint: (...args: unknown[]) =>
+    mockComputeKeyFingerprint(...args),
+}));
+
+// Mock signupState stores (used by addChat guard)
+vi.mock("../../../stores/signupState", () => ({
+  forcedLogoutInProgress: { subscribe: vi.fn((cb: (v: boolean) => void) => { cb(false); return () => {}; }) },
+  isLoggingOut: { subscribe: vi.fn((cb: (v: boolean) => void) => { cb(false); return () => {}; }) },
+}));
+
+// Mock svelte/store get()
+vi.mock("svelte/store", () => ({
+  get: () => false,
+}));
+
+import { encryptChatForStorage } from "../chatCrudOperations";
+import type { Chat } from "../../../types/chat";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChat(overrides: Partial<Chat> = {}): Chat {
+  return {
+    chat_id: "test-chat-123",
+    encrypted_title: null,
+    encrypted_icon: null,
+    encrypted_category: null,
+    encrypted_chat_key: null,
+    messages_v: 1,
+    title_v: 1,
+    draft_v: 0,
+    encrypted_draft_md: null,
+    encrypted_draft_preview: null,
+    last_edited_overall_timestamp: 1000,
+    unread_count: 0,
+    created_at: 1000,
+    updated_at: 1000,
+    ...overrides,
+  } as Chat;
+}
+
+function makeDbInstance() {
+  return {
+    db: null,
+    CHATS_STORE_NAME: "chats",
+    init: vi.fn().mockResolvedValue(undefined),
+    getTransaction: vi.fn(),
+    getChat: vi.fn().mockResolvedValue(null),
+    getEncryptedChatKey: vi.fn().mockResolvedValue(null),
+  };
+}
+
+const fakeKey = new Uint8Array(32).fill(42);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("encryptChatForStorage — isFromSync guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: no key found anywhere
+    mockGetKeySync.mockReturnValue(null);
+    mockDecryptChatKeyWithMasterKey.mockResolvedValue(null);
+    mockEncryptChatKeyWithMasterKey.mockResolvedValue(null);
+    mockCreateKeyForNewChat.mockReturnValue(fakeKey);
+  });
+
+  it("creates a new key for a genuinely new chat (isFromSync=false, default)", async () => {
+    const db = makeDbInstance();
+    const chat = makeChat();
+
+    mockEncryptChatKeyWithMasterKey.mockResolvedValue("encrypted-key-base64");
+
+    const result = await encryptChatForStorage(db as any, chat);
+
+    // Step 4 should have been called — this IS a new chat
+    expect(mockCreateKeyForNewChat).toHaveBeenCalledWith("test-chat-123");
+    expect(result.encrypted_chat_key).toBe("encrypted-key-base64");
+    expect(result.key_fingerprint).toBe("abcd1234");
+  });
+
+  it("NEVER creates a new key when isFromSync=true (sync guard)", async () => {
+    const db = makeDbInstance();
+    const chat = makeChat();
+
+    const result = await encryptChatForStorage(db as any, chat, {
+      isFromSync: true,
+    });
+
+    // Step 4 must NOT be called — this is a synced chat
+    expect(mockCreateKeyForNewChat).not.toHaveBeenCalled();
+    // Chat should be returned without key_fingerprint (no key was loaded)
+    expect(result.encrypted_chat_key).toBeNull();
+  });
+
+  it("uses existing key from ChatKeyManager even when isFromSync=true", async () => {
+    const db = makeDbInstance();
+    const chat = makeChat();
+
+    // Key already in ChatKeyManager (Step 1 succeeds)
+    mockGetKeySync.mockReturnValue(fakeKey);
+    mockEncryptChatKeyWithMasterKey.mockResolvedValue("encrypted-existing");
+
+    const result = await encryptChatForStorage(db as any, chat, {
+      isFromSync: true,
+    });
+
+    // Should use existing key, not create a new one
+    expect(mockCreateKeyForNewChat).not.toHaveBeenCalled();
+    expect(result.encrypted_chat_key).toBe("encrypted-existing");
+    expect(result.key_fingerprint).toBe("abcd1234");
+  });
+
+  it("decrypts server-provided encrypted_chat_key during sync (Step 2)", async () => {
+    const db = makeDbInstance();
+    const chat = makeChat({ encrypted_chat_key: "server-encrypted-key" });
+
+    // Step 2: server key decrypts successfully
+    mockDecryptChatKeyWithMasterKey.mockResolvedValue(fakeKey);
+    mockEncryptChatKeyWithMasterKey.mockResolvedValue("re-encrypted");
+
+    const result = await encryptChatForStorage(db as any, chat, {
+      isFromSync: true,
+    });
+
+    // Should decrypt and inject the server key
+    expect(mockDecryptChatKeyWithMasterKey).toHaveBeenCalledWith(
+      "server-encrypted-key",
+    );
+    expect(mockInjectKey).toHaveBeenCalledWith(
+      "test-chat-123",
+      fakeKey,
+      "master_key",
+    );
+    expect(mockCreateKeyForNewChat).not.toHaveBeenCalled();
+    // Should preserve the original server-encrypted key
+    expect(result.encrypted_chat_key).toBe("server-encrypted-key");
+  });
+
+  it("falls back to IDB key during sync (Step 3)", async () => {
+    const db = makeDbInstance();
+    const chat = makeChat(); // No encrypted_chat_key from server
+
+    // Step 3: IDB has the key
+    db.getChat.mockResolvedValue({
+      chat_id: "test-chat-123",
+      encrypted_chat_key: "idb-encrypted-key",
+    });
+    mockDecryptChatKeyWithMasterKey.mockResolvedValue(fakeKey);
+
+    await encryptChatForStorage(db as any, chat, {
+      isFromSync: true,
+    });
+
+    expect(mockDecryptChatKeyWithMasterKey).toHaveBeenCalledWith(
+      "idb-encrypted-key",
+    );
+    expect(mockInjectKey).toHaveBeenCalledWith(
+      "test-chat-123",
+      fakeKey,
+      "master_key",
+    );
+    expect(mockCreateKeyForNewChat).not.toHaveBeenCalled();
+  });
+
+  it("returns early without key when all steps fail during sync", async () => {
+    const db = makeDbInstance();
+    const chat = makeChat(); // No server key
+    db.getChat.mockResolvedValue(null); // No IDB key
+
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await encryptChatForStorage(db as any, chat, {
+      isFromSync: true,
+    });
+
+    // Must NOT create a key
+    expect(mockCreateKeyForNewChat).not.toHaveBeenCalled();
+
+    // Should log the sync guard warning
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("SYNC GUARD"),
+    );
+
+    // Chat returned without key data
+    expect(result.encrypted_chat_key).toBeNull();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("skips encryption for public chats regardless of isFromSync", async () => {
+    const db = makeDbInstance();
+    const demoChat = makeChat({ chat_id: "demo-welcome" });
+
+    const result = await encryptChatForStorage(db as any, demoChat, {
+      isFromSync: true,
+    });
+
+    expect(mockCreateKeyForNewChat).not.toHaveBeenCalled();
+    expect(mockGetKeySync).not.toHaveBeenCalled();
+    expect(result.chat_id).toBe("demo-welcome");
+  });
+});

--- a/frontend/packages/ui/src/services/db/chatCrudOperations.ts
+++ b/frontend/packages/ui/src/services/db/chatCrudOperations.ts
@@ -43,7 +43,7 @@ const MESSAGES_STORE_NAME = "messages";
 /**
  * Extract title from TipTap JSON content (first line of text)
  */
-function extractTitleFromContent(content: TiptapJSON): string {
+function _extractTitleFromContent(content: TiptapJSON): string {
   if (!content) return "";
   try {
     const firstTextNode = content.content?.[0]?.content?.[0];
@@ -77,6 +77,7 @@ function extractTitleFromContent(content: TiptapJSON): string {
 export async function encryptChatForStorage(
   dbInstance: ChatDatabaseInstance,
   chat: Chat,
+  options?: { isFromSync?: boolean },
 ): Promise<Chat> {
   // Skip encryption entirely for public chats (demo + legal) - they're public content
   // Add null check to prevent TypeError when chat.chat_id is undefined
@@ -153,7 +154,23 @@ export async function encryptChatForStorage(
   }
 
   // Step 4: genuinely new chat — create key through ChatKeyManager (single source of truth)
+  // CRITICAL GUARD: During sync (isFromSync=true), NEVER create a new key for a chat.
+  // Creating a new random key for a synced chat overwrites the original key and makes
+  // all existing messages permanently undecryptable (the original key is lost).
+  // This was the root cause of OPE-314-class decryption failures after logout/login.
   if (!chatKey) {
+    if (options?.isFromSync) {
+      console.error(
+        `[ChatDatabase] ⚠️ SYNC GUARD: No chat key available for synced chat ${chat.chat_id}. ` +
+          `Refusing to create a new key — this would corrupt existing messages. ` +
+          `The chat will be stored without a key; it will be decryptable once the ` +
+          `correct key is loaded via receiveKeyFromServer().`,
+      );
+      // Store the chat without a key — it will be populated later when
+      // the correct key arrives via Phase 1a receiveKeyFromServer() or
+      // a subsequent sync that includes encrypted_chat_key.
+      return encryptedChat;
+    }
     console.log(
       `[ChatDatabase] Generating NEW chat key for chat ${chat.chat_id} (new chat creation)`,
     );
@@ -292,6 +309,7 @@ export async function addChat(
   dbInstance: ChatDatabaseInstance,
   chat: Chat,
   transaction?: IDBTransaction,
+  options?: { isFromSync?: boolean },
 ): Promise<void> {
   console.debug(
     `[ChatDatabase] addChat called for chat ${chat.chat_id} with transaction: ${!!transaction}`,
@@ -337,7 +355,7 @@ export async function addChat(
 
   // CRITICAL FIX: Do async encryption work BEFORE using the transaction
   // This ensures the transaction is still active when we try to use it
-  const chatToSave = await encryptChatForStorage(dbInstance, chatWithDefaults);
+  const chatToSave = await encryptChatForStorage(dbInstance, chatWithDefaults, options);
   delete chatToSave.messages;
 
   return new Promise<void>((resolve, reject) => {

--- a/frontend/packages/ui/src/services/debugUtils.ts
+++ b/frontend/packages/ui/src/services/debugUtils.ts
@@ -2378,9 +2378,10 @@ export async function inspectChat(
   const syncResp = await fetchServerSyncStatus([chatId]);
   const serverStatus = syncResp?.chats?.[0];
   const syncLines = formatServerChatSync(serverStatus);
+  const serverLabel = getServerLabel();
   const serverSyncBlock =
     "\n\n─────────────────────────────────────────────\n" +
-    "🌐 SERVER SYNC\n" +
+    `🌐 SERVER SYNC (${serverLabel})\n` +
     syncLines.join("\n");
 
   const fullReport = report + serverSyncBlock;
@@ -2731,9 +2732,10 @@ export async function inspectEmbed(
   const embedSyncResp = await fetchServerSyncStatus(undefined, [embedId]);
   const embedServerStatus = embedSyncResp?.embeds?.[0];
   const embedSyncLines = formatServerEmbedSync(embedServerStatus);
+  const embedServerLabel = getServerLabel();
   const embedServerSyncBlock =
     "\n\n─────────────────────────────────────────────\n" +
-    "🌐 SERVER SYNC\n" +
+    `🌐 SERVER SYNC (${embedServerLabel})\n` +
     embedSyncLines.join("\n");
 
   const fullReport = report + embedServerSyncBlock;
@@ -3695,6 +3697,7 @@ async function runClientHealthCheck(): Promise<void> {
   // 10. Server sync status — batch check all local chats against server
   // We collect all local chat IDs, then send them in batches of SERVER_SYNC_BATCH_SIZE.
   // Any chat that is found locally but missing on the server (or has version mismatch) is flagged.
+  const batchServerLabel = getServerLabel();
   const serverSyncIssues: string[] = [];
   try {
     const db6 = await openDB();
@@ -3799,13 +3802,13 @@ async function runClientHealthCheck(): Promise<void> {
 
       if (checkedCount > 0) {
         if (driftCount === 0 && missingCount === 0) {
-          allOk.push(`Server sync: all ${checkedCount} chats in sync`);
+          allOk.push(`Server sync (${batchServerLabel}): all ${checkedCount} chats in sync`);
         } else {
           const parts: string[] = [];
           if (driftCount > 0) parts.push(`${driftCount} drift`);
           if (missingCount > 0) parts.push(`${missingCount} missing`);
           allIssues.push(
-            `Server sync: ${parts.join(", ")} (of ${checkedCount} checked)`,
+            `Server sync (${batchServerLabel}): ${parts.join(", ")} (of ${checkedCount} checked)`,
           );
           for (const detail of driftDetails.slice(0, 10)) {
             serverSyncIssues.push(detail);
@@ -3928,6 +3931,7 @@ function showDebugHelp(): void {
       "  window.debug()                            — quick client health check\n" +
       "  window.debug.help()                       — show this help\n\n" +
       "  Chat / Message:\n" +
+      "  await window.debug.chat()                 — inspect active chat (auto-detected from URL)\n" +
       '  await window.debug.chat("id")             — concise report (full details if issues found)\n' +
       '  await window.debug.chat("id", {verbose: true})   — always show full details\n' +
       '  await window.debug.chat("id", {download: true})  — download report as .txt\n' +
@@ -3936,6 +3940,7 @@ function showDebugHelp(): void {
       '  await window.debug.message("id")          — message health check & decrypted fields\n' +
       '  await window.debug.message("id", {verbose: true})  — full details with content\n\n' +
       "  Embeds:\n" +
+      "  await window.debug.embed()                — inspect embed (auto-detected from URL)\n" +
       '  await window.debug.embed("id")            — embed inspection report\n' +
       '  await window.debug.embed("id", {full: true})      — show all fields untruncated\n' +
       '  await window.debug.embed("id", {download: true})  — download embed report\n' +
@@ -4175,6 +4180,22 @@ interface ServerSyncResponse {
 const SERVER_SYNC_BATCH_SIZE = 20;
 
 /**
+ * Return a human-readable label for the server the app is connected to.
+ * Derived from the current hostname (runtime) rather than build-time VITE_ENV
+ * so it accurately reflects which API the debug sync check hit.
+ */
+function getServerLabel(): string {
+  if (typeof window === "undefined") return "unknown";
+  const host = window.location.hostname;
+  if (host.includes("dev.")) return `dev — ${host}`;
+  if (host === "openmates.org" || host === "www.openmates.org")
+    return `production — ${host}`;
+  if (host === "localhost" || host === "127.0.0.1")
+    return `local dev — ${host}`;
+  return host; // self-hosted or other
+}
+
+/**
  * Fetch server-side sync status for a batch of chat IDs or embed IDs.
  *
  * Uses the JWT session cookie (same as all other user-facing API calls).
@@ -4313,6 +4334,45 @@ function formatServerEmbedSync(
   return lines;
 }
 
+/**
+ * Auto-detect the active chat ID from the URL hash or activeChatStore.
+ * Checks URL hash first (#chat-id=...) since it's synchronous and reliable,
+ * then falls back to the in-memory store.
+ */
+function getActiveChatIdFromContext(): string | null {
+  if (typeof window === "undefined") return null;
+
+  // 1. URL hash: #chat-id=<uuid> (may have additional params like &messageid=...)
+  const hash = window.location.hash;
+  const chatIdMatch = hash.match(/chat-id=([a-f0-9-]{36})/i);
+  if (chatIdMatch) return chatIdMatch[1];
+
+  // 2. Share page URL: /share/chat/<uuid>
+  const pathMatch = window.location.pathname.match(/\/share\/chat\/([a-f0-9-]{36})/i);
+  if (pathMatch) return pathMatch[1];
+
+  return null;
+}
+
+/**
+ * Auto-detect an embed ID from the URL context.
+ * Checks share embed pages (/share/embed/<uuid>) and URL hash (#embed-id=...).
+ */
+function getEmbedIdFromContext(): string | null {
+  if (typeof window === "undefined") return null;
+
+  // 1. Share embed page: /share/embed/<uuid>
+  const pathMatch = window.location.pathname.match(/\/share\/embed\/([a-f0-9-]{36})/i);
+  if (pathMatch) return pathMatch[1];
+
+  // 2. URL hash: #embed-id=<uuid>
+  const hash = window.location.hash;
+  const embedIdMatch = hash.match(/embed-id=([a-f0-9-]{36})/i);
+  if (embedIdMatch) return embedIdMatch[1];
+
+  return null;
+}
+
 export function initDebugUtils(): void {
   if (typeof window === "undefined") return;
 
@@ -4324,14 +4384,28 @@ export function initDebugUtils(): void {
     /** Show all available commands */
     help: showDebugHelp,
 
-    /** Generate a copyable chat inspection report */
+    /** Generate a copyable chat inspection report (auto-detects active chat if no ID given) */
     chat: (
-      chatId: string,
+      chatId?: string,
       opts: { download?: boolean; verbose?: boolean } = {},
-    ) => inspectChat(chatId, opts),
+    ) => {
+      const resolvedId = chatId || getActiveChatIdFromContext();
+      if (!resolvedId) {
+        console.error("[debug.chat] No chat ID provided and no active chat detected.\n  Usage: debug.chat('chat-id-here')");
+        return Promise.resolve();
+      }
+      return inspectChat(resolvedId, opts);
+    },
 
     /** Verbose console dump of a chat (all messages, all fields) */
-    chatVerbose: (chatId: string) => debugChat(chatId),
+    chatVerbose: (chatId?: string) => {
+      const resolvedId = chatId || getActiveChatIdFromContext();
+      if (!resolvedId) {
+        console.error("[debug.chatVerbose] No chat ID provided and no active chat detected.");
+        return Promise.resolve();
+      }
+      return debugChat(resolvedId);
+    },
 
     /** List all chats with consistency check */
     chats: () => debugAllChats(),
@@ -4342,9 +4416,15 @@ export function initDebugUtils(): void {
       opts: { download?: boolean; verbose?: boolean; hideKeys?: boolean } = {},
     ) => inspectMessage(messageId, opts),
 
-    /** Generate a copyable embed inspection report */
-    embed: (embedId: string, opts: { download?: boolean; full?: boolean } = {}) =>
-      inspectEmbed(embedId, opts),
+    /** Generate a copyable embed inspection report (auto-detects from URL if no ID given) */
+    embed: (embedId?: string, opts: { download?: boolean; full?: boolean } = {}) => {
+      const resolvedId = embedId || getEmbedIdFromContext();
+      if (!resolvedId) {
+        console.error("[debug.embed] No embed ID provided and none detected from URL.\n  Usage: debug.embed('embed-id-here')");
+        return Promise.resolve();
+      }
+      return inspectEmbed(resolvedId, opts);
+    },
 
     /** Decrypt and show raw embed content */
     decrypt: async (embedId: string) => {
@@ -4353,9 +4433,17 @@ export function initDebugUtils(): void {
     },
 
     /** Shorthand: download a chat or embed report as .txt */
-    download: (type: "chat" | "embed", id: string) => {
-      if (type === "chat") return inspectChat(id, { download: true });
-      if (type === "embed") return inspectEmbed(id, { download: true });
+    download: (type: "chat" | "embed", id?: string) => {
+      if (type === "chat") {
+        const resolvedId = id || getActiveChatIdFromContext();
+        if (!resolvedId) { console.error("[debug.download] No chat ID — open a chat first or pass an ID."); return; }
+        return inspectChat(resolvedId, { download: true });
+      }
+      if (type === "embed") {
+        const resolvedId = id || getEmbedIdFromContext();
+        if (!resolvedId) { console.error("[debug.download] No embed ID provided."); return; }
+        return inspectEmbed(resolvedId, { download: true });
+      }
       console.error(`Unknown type "${type}". Use "chat" or "embed".`);
     },
 


### PR DESCRIPTION
## Summary

This PR stabilizes the E2E test suite (signup, chat-flow, passkey flows), fixes several chat sync race conditions, improves geocoding accuracy for listing addresses, and replaces hardcoded English strings in the health appointment embed with i18n keys.

## Bug Fixes

**Chat sync & streaming stability**
- Fix ActiveChat bleed-through where synced/streamed messages could corrupt the active chat during IDB reloads
- Add `isFromSync` guard to prevent chat key corruption during sync operations
- Fix `messages_v` not being incremented for focus mode activation messages
- Fix demo message ordering — "for-everyone" message no longer appears after AI response
- Wait for phased sync to complete before navigating to chat after re-login

**E2E test selectors & reliability**
- Replace CSS class selector `input.tfa-input` with `getByTestId('tfa-input')` across all signup specs
- Add `data-testid='credits-amount'` to SettingsMainHeader credits span
- Add `data-testid` for `chat-header-icon` and `chat-header-summary` in ChatHeader
- Use broader locators for Polar billing address fields (address, city, state, zip)
- Wait for Stripe iframe load after Polar→Stripe switch in signup specs
- Add switch-to-stripe handling in signup-flow-passkey spec

**Geocoding**
- Fix geocode to resolve listing addresses to street-level instead of city center

**i18n**
- Replace hardcoded English strings in HealthAppointmentEmbedFullscreen with i18n keys

## Improvements

**E2E test performance**
- Reduce signup spec timeouts to 10s default (30s for 3rd-party iframes, 60s for payment confirmation)
- Reduce signup-flow-polar.spec.ts timeouts to match other specs

**Testing infrastructure**
- Add encryption key integrity assertions to chat-flow.spec.ts
- Add missing `chat_flow_capital` fixture for chat-flow.spec.ts
- Scope encryption assertions to phase-specific console logs in chat-flow spec
- Add chat header title/summary/icon assertions to chat-flow.spec.ts
- Add `encryptChatForStorage` unit test suite

**Developer tooling**
- Add server labels (dev/production) to `window.debug.chat/embed` output
- Auto production cross-check in `debug.py embed` and `chat` commands
- Auto-detect active ID from URL in `debug.chat()` and `debug.embed()`
- Hint to try `--production` when issue not found locally

## Other Changes

- Add e2e-test-investigator subagent and testing rule updates
- Increase signup-flow test timeout to 600s for full flow coverage