### PR TITLE
feat: reminder quick presets, publish-newsletter skill, newsletter update

### DIFF
--- a/.claude/skills/publish-newsletter/SKILL.md
+++ b/.claude/skills/publish-newsletter/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: publish-newsletter
+description: Publish a newsletter issue from openmates-marketing into the web app and optionally send a test email — runs publish_newsletter.py, rebuilds translations, deploys, then optionally test-sends
+user-invocable: true
+argument-hint: "<campaign-folder-name> [--test-to <email>]"
+---
+
+## Overview
+
+Takes a campaign folder from `openmates-marketing/campaigns/` and:
+1. Runs `publish_newsletter.py` to generate/update the manifest, demo chat TS, and i18n YAML
+2. Rebuilds translations
+3. Deploys via `sessions.py deploy`
+4. Optionally sends a test email via `send_newsletter.py --test-to`
+
+The marketing repo is mounted at `/openmates-marketing` inside the `api` container.
+
+## Input
+
+The user provides a campaign folder name (under `openmates-marketing/campaigns/`) and optionally a test email:
+
+```
+/publish-newsletter newsletter_update_april_15_2026
+/publish-newsletter newsletter_update_april_15_2026 --test-to testing@openmates.org
+```
+
+Or the user may just describe which newsletter to publish — infer the folder name from
+`ls /home/superdev/projects/openmates-marketing/campaigns/`.
+
+## Steps
+
+### 1. Resolve campaign folder
+
+List available campaigns and confirm the target folder:
+
+```bash
+ls /home/superdev/projects/openmates-marketing/campaigns/
+```
+
+Read `meta.yml` in the campaign folder to confirm the slug, category, and video config:
+
+```bash
+cat /home/superdev/projects/openmates-marketing/campaigns/<folder>/meta.yml
+```
+
+### 2. Check both language files are consistent
+
+Before publishing, verify EN and DE have the same structural changes (same social links,
+same sections, matching `[video]` and `[cta]` markers):
+
+```bash
+grep -n "YouTube\|video\|\[cta\]" \
+  /home/superdev/projects/openmates-marketing/campaigns/<folder>/newsletter_EN.md \
+  /home/superdev/projects/openmates-marketing/campaigns/<folder>/newsletter_DE.md
+```
+
+Flag any mismatch to the user before continuing.
+
+### 3. Publish (generate repo files)
+
+```bash
+docker exec api python /app/backend/scripts/publish_newsletter.py \
+    --issue-dir /openmates-marketing/campaigns/<folder>/
+```
+
+This writes/overwrites:
+- `backend/newsletters/issues/<slug>.yml` — email manifest
+- `frontend/packages/ui/src/demo_chats/data/<kind>_<snake_slug>.ts` — demo chat
+- `frontend/packages/ui/src/i18n/sources/demo_chats/<kind>_<snake_slug>.yml` — i18n source
+- Patches `newsletterChatStore.ts` (import + registration)
+
+### 4. Rebuild translations
+
+```bash
+cd frontend/packages/ui && npm run build:translations
+```
+
+### 5. Deploy
+
+Start a session if one isn't already active:
+
+```bash
+python3 scripts/sessions.py start --mode feature --task "publish newsletter: <slug>"
+```
+
+Track and deploy the changed files:
+
+```bash
+python3 scripts/sessions.py deploy --session <SESSION_ID> \
+    --title "feat(newsletter): publish <slug>" \
+    --message "Re-publish <slug> with updated content from openmates-marketing." \
+    --end
+```
+
+### 6. Send test email (if requested)
+
+```bash
+docker exec -i api python /app/backend/scripts/send_newsletter.py \
+    --slug <slug> \
+    --test-to <email> \
+    --lang en
+```
+
+Confirm "Test send: OK" in the output. Report the landing page URL from the script output.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `openmates-marketing/campaigns/<folder>/meta.yml` | Slug, category, video config, CTA |
+| `openmates-marketing/campaigns/<folder>/newsletter_EN.md` | EN body (frontmatter: title/subject, subtitle, cta_text) |
+| `openmates-marketing/campaigns/<folder>/newsletter_DE.md` | DE body |
+| `backend/newsletters/issues/<slug>.yml` | Generated email manifest (read by send_newsletter.py) |
+| `backend/scripts/publish_newsletter.py` | Publisher — reads marketing MD, writes repo files |
+| `backend/scripts/send_newsletter.py` | Dispatcher — reads manifest, sends via Brevo |
+| `frontend/packages/ui/src/demo_chats/data/` | Generated demo chat TS |
+| `frontend/packages/ui/src/i18n/sources/demo_chats/` | Generated i18n YAML source |
+
+## Language notes
+
+- `SUPPORTED_LANGS = ("en", "de")` — only EN and DE bodies are authored
+- All other languages (FR, ES, ZH, …) fall back to EN at send time
+- The i18n YAML contains stubs for 21 languages; untranslated locales also fall back to EN
+
+## Sending the real broadcast
+
+This skill only handles publishing + test sends. The actual broadcast is a separate,
+destructive, irreversible action — run it manually:
+
+```bash
+docker exec -it api python /app/backend/scripts/send_newsletter.py \
+    --slug <slug> \
+    --send
+```
+
+The script requires an interactive TTY (`-it`) and prompts for explicit confirmation
+before sending. `sent_at` in the manifest is set after a successful broadcast;
+a second run requires `--resend-confirm`.

--- a/deployment/prod_server/Caddyfile
+++ b/deployment/prod_server/Caddyfile
@@ -96,7 +96,7 @@ api.openmates.org {
 	# calls it with credentials: include (session cookie) — browsers block wildcard CORS
 	# with credentials, so it must go through FastAPI's CORSMiddleware (specific origin).
 	@webapp_general_options {
-		path /v1/auth/* /v1/settings/* /v1/payments/* /v1/share/* /v1/newsletter/* /v1/block-email /v1/admin/* /v1/debug/* /v1/demo/* /v1/apps/travel/booking-link /v1/apps/travel/flight-details /v1/apps/audio/skills/transcribe /v1/daily-inspirations /v1/daily-inspirations/* /v1/embeds/presigned-url /v1/push /v1/push/* /v1/creators /v1/creators/* /v1/users/* /v1/wikipedia/* /v1/telemetry/* /v1/client-logs
+		path /v1/auth/* /v1/settings/* /v1/payments/* /v1/share/* /v1/newsletter/* /v1/block-email /v1/admin/* /v1/debug/* /v1/demo/* /v1/apps/travel/booking-link /v1/apps/travel/flight-details /v1/apps/audio/skills/transcribe /v1/apps/reminder/skills/* /v1/daily-inspirations /v1/daily-inspirations/* /v1/embeds/presigned-url /v1/push /v1/push/* /v1/creators /v1/creators/* /v1/users/* /v1/wikipedia/* /v1/telemetry/* /v1/client-logs
 		method OPTIONS
 	}
 
@@ -112,7 +112,7 @@ api.openmates.org {
 	# NOTE: /v1/geocode/* is intentionally NOT here — it is public (no auth) and handled
 	# by @public_api_paths with wildcard CORS so unauthenticated users can access it.
 	@webapp_actual {
-		path /v1/auth/* /v1/settings/* /v1/payments/* /v1/share/* /v1/newsletter/* /v1/block-email /v1/admin/* /v1/debug/* /v1/demo/* /v1/apps/travel/booking-link /v1/apps/travel/flight-details /v1/apps/audio/skills/transcribe /v1/daily-inspirations /v1/daily-inspirations/* /v1/embeds/presigned-url /v1/push /v1/push/* /v1/creators /v1/creators/* /v1/users/* /v1/wikipedia/* /v1/telemetry/* /v1/client-logs
+		path /v1/auth/* /v1/settings/* /v1/payments/* /v1/share/* /v1/newsletter/* /v1/block-email /v1/admin/* /v1/debug/* /v1/demo/* /v1/apps/travel/booking-link /v1/apps/travel/flight-details /v1/apps/audio/skills/transcribe /v1/apps/reminder/skills/* /v1/daily-inspirations /v1/daily-inspirations/* /v1/embeds/presigned-url /v1/push /v1/push/* /v1/creators /v1/creators/* /v1/users/* /v1/wikipedia/* /v1/telemetry/* /v1/client-logs
 		not method OPTIONS
 	}
 

--- a/frontend/apps/web_app/tests/reminder-button-settings.spec.ts
+++ b/frontend/apps/web_app/tests/reminder-button-settings.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-require-imports */
 export {};
 
@@ -157,27 +156,26 @@ test('reminder — settings page: create reminder via top-bar button and verify 
 	// ── Step 3: Verify the reminder creation form and chat context ──
 	log('Verifying reminder creation form...');
 
-	// The settings panel should now show the reminder creation page
-	const dateInput = page.locator('#settings-reminder-date');
-	await expect(dateInput).toBeVisible({ timeout: 10000 });
-	log('Reminder creation form is visible.');
+	// The "When?" dropdown should be visible by default (new quick-preset UI)
+	const whenDropdown = page.getByTestId('settings-dropdown').nth(1);
+	await expect(whenDropdown).toBeVisible({ timeout: 10000 });
+	log('Reminder creation form is visible (When? dropdown found).');
 
 	// Verify chat context is shown (the current chat title should appear)
 	const chatContext = page.getByTestId('chat-context');
 	await expect(chatContext).toBeVisible({ timeout: 5000 });
 	log('Chat context visible in reminder form.');
 
-	// Verify target type dropdown defaults to "This chat"
-	const targetDropdown = page.getByTestId('settings-dropdown').first();
-	if (await targetDropdown.isVisible({ timeout: 3000 }).catch(() => false)) {
-		const selectedValue = await targetDropdown.inputValue();
-		log(`Target type: ${selectedValue}`);
-	}
+	// ── Step 4: Select "Custom" to reveal the date/time pickers, then fill them ──
+	log('Selecting Custom preset to reveal date/time inputs...');
+	await whenDropdown.selectOption('custom');
+	await page.waitForTimeout(300);
 
-	const timeInput = page.locator('#settings-reminder-time');
+	const dateInput = page.getByTestId('settings-reminder-date');
+	await expect(dateInput).toBeVisible({ timeout: 5000 });
+	const timeInput = page.getByTestId('settings-reminder-time');
 	await expect(timeInput).toBeVisible({ timeout: 5000 });
 
-	// ── Step 4: Fill in the form ──
 	const { date, time } = getOneMinuteFromNow();
 	log(`Setting reminder for: ${date} ${time}`);
 

--- a/frontend/packages/ui/src/components/settings/elements/SettingsInput.svelte
+++ b/frontend/packages/ui/src/components/settings/elements/SettingsInput.svelte
@@ -10,7 +10,7 @@
 -->
 <script lang="ts">
     /** Input type — standard HTML input types */
-    type InputType = 'text' | 'email' | 'password' | 'number' | 'search' | 'url' | 'tel';
+    type InputType = 'text' | 'email' | 'password' | 'number' | 'search' | 'url' | 'tel' | 'date' | 'time';
 
     /** inputmode — virtual keyboard hint for mobile */
     type InputMode = 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
@@ -23,11 +23,12 @@
         name = '',
         id = '',
         ariaLabel = '',
-        autocomplete = 'off' as AutoFill,
+        autocomplete = 'off',
         spellcheck = undefined as boolean | undefined,
         maxlength = undefined,
         pattern = undefined as string | undefined,
         inputmode = undefined as InputMode | undefined,
+        min = undefined as string | undefined,
         hasError = false,
         dataTestid = '',
         onInput = undefined,
@@ -42,9 +43,10 @@
         name?: string;
         id?: string;
         ariaLabel?: string;
-        autocomplete?: AutoFill;
+        autocomplete?: string;
         spellcheck?: boolean | undefined;
         maxlength?: number | undefined;
+        min?: string | undefined;
         pattern?: string | undefined;
         inputmode?: InputMode | undefined;
         hasError?: boolean;
@@ -79,6 +81,7 @@
         {autocomplete}
         spellcheck={spellcheck}
         maxlength={maxlength}
+        min={min}
         pattern={pattern}
         inputmode={inputmode}
         aria-label={ariaLabel || placeholder}

--- a/frontend/packages/ui/src/components/settings/notifications/SettingsReminders.svelte
+++ b/frontend/packages/ui/src/components/settings/notifications/SettingsReminders.svelte
@@ -27,6 +27,8 @@
 	import SettingsDropdown from '../elements/SettingsDropdown.svelte';
 	import SettingsInfoBox from '../elements/SettingsInfoBox.svelte';
 	import SettingsSectionHeading from '../elements/SettingsSectionHeading.svelte';
+	import SettingsButton from '../elements/SettingsButton.svelte';
+	import SettingsInput from '../elements/SettingsInput.svelte';
 	import { chatMetadataCache } from '../../../services/chatMetadataCache';
 	import { chatDB } from '../../../services/db';
 	import {
@@ -86,6 +88,8 @@
 	let time = $state('');
 	/** Reminder type: 'this_chat' (chat reminder notification) or 'new_task' (new chat + AI task) */
 	let reminderMode = $state<'this_chat' | 'new_task'>('this_chat');
+	/** Quick preset selection; 'custom' reveals the Day/Time pickers */
+	let whenPreset = $state('in_30_min');
 	let actionPrompt = $state('');
 	let repeatType = $state('none');
 	let customInterval = $state('1');
@@ -115,6 +119,55 @@
 	});
 
 	let showCustomRepeat = $derived(repeatType === 'custom');
+	let showCustomDatetime = $derived(whenPreset === 'custom');
+
+	/** Compute date/time strings for a given preset key (called at submit time for relative presets). */
+	function computePresetDatetime(preset: string): { date: string; time: string } {
+		const now = new Date();
+		const fmt = (d: Date) =>
+			`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+		const fmtTime = (h: number, m = 0) =>
+			`${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+
+		if (preset === 'in_10_min') {
+			const t = new Date(now.getTime() + 10 * 60 * 1000);
+			return { date: fmt(t), time: fmtTime(t.getHours(), t.getMinutes()) };
+		}
+		if (preset === 'in_30_min') {
+			const t = new Date(now.getTime() + 30 * 60 * 1000);
+			return { date: fmt(t), time: fmtTime(t.getHours(), t.getMinutes()) };
+		}
+		if (preset === 'in_1_hour') {
+			const t = new Date(now.getTime() + 60 * 60 * 1000);
+			return { date: fmt(t), time: fmtTime(t.getHours(), t.getMinutes()) };
+		}
+		if (preset === 'today_8pm') {
+			return { date: fmt(now), time: '20:00' };
+		}
+		if (preset === 'tomorrow_9am') {
+			const t = new Date(now);
+			t.setDate(t.getDate() + 1);
+			return { date: fmt(t), time: '09:00' };
+		}
+		if (preset === 'saturday_11am') {
+			const t = new Date(now);
+			const day = t.getDay();
+			const daysUntilSat = day === 6 ? 7 : 6 - day;
+			t.setDate(t.getDate() + daysUntilSat);
+			return { date: fmt(t), time: '11:00' };
+		}
+		return { date: '', time: '' };
+	}
+
+	let whenOptions = $derived([
+		{ value: 'in_10_min', label: $text('reminder.settings.preset_10min') },
+		{ value: 'in_30_min', label: $text('reminder.settings.preset_30min') },
+		{ value: 'in_1_hour', label: $text('reminder.settings.preset_1hour') },
+		{ value: 'today_8pm', label: $text('reminder.settings.preset_today_8pm') },
+		{ value: 'tomorrow_9am', label: $text('reminder.settings.preset_tomorrow_9am') },
+		{ value: 'saturday_11am', label: $text('reminder.settings.preset_saturday_11am') },
+		{ value: 'custom', label: $text('reminder.settings.preset_custom') }
+	]);
 
 	let repeatOptions = $derived([
 		{ value: 'none', label: $text('reminder.panel.repeat_none') },
@@ -141,9 +194,18 @@
 	async function handleSubmit() {
 		errorMessage = '';
 
-		if (!date || !time) return;
+		let resolvedDate = date;
+		let resolvedTime = time;
 
-		const triggerDatetime = `${date}T${time}:00`;
+		if (whenPreset !== 'custom') {
+			const computed = computePresetDatetime(whenPreset);
+			resolvedDate = computed.date;
+			resolvedTime = computed.time;
+		}
+
+		if (!resolvedDate || !resolvedTime) return;
+
+		const triggerDatetime = `${resolvedDate}T${resolvedTime}:00`;
 		const triggerMs = new Date(triggerDatetime).getTime();
 		if (triggerMs <= Date.now()) {
 			errorMessage = $text('reminder.panel.error_past');
@@ -292,35 +354,46 @@
 		/>
 	{/if}
 
-	<!-- 5. Day? -->
+	<!-- 5. When? -->
 	<SettingsSectionHeading
-		icon="calendar"
-		title={$text('reminder.settings.day_heading')}
+		icon="clock"
+		title={$text('reminder.settings.when_heading')}
 	/>
-	<div class="native-input-wrapper">
-		<input
+	<SettingsDropdown
+		bind:value={whenPreset}
+		options={whenOptions}
+		ariaLabel={$text('reminder.settings.when_heading')}
+	/>
+
+	<!-- 5a. Day? — only when Custom is selected -->
+	{#if showCustomDatetime}
+		<SettingsSectionHeading
+			icon="calendar"
+			title={$text('reminder.settings.day_heading')}
+		/>
+		<SettingsInput
 			id="settings-reminder-date"
-			class="native-input"
+			dataTestid="settings-reminder-date"
 			type="date"
 			bind:value={date}
 			min={todayStr}
+			ariaLabel={$text('reminder.settings.day_heading')}
 		/>
-	</div>
 
-	<!-- 6. Time? -->
-	<SettingsSectionHeading
-		icon="clock"
-		title={$text('reminder.settings.time_heading')}
-	/>
-	<div class="native-input-wrapper">
-		<input
+		<!-- 5b. Time? — only when Custom is selected -->
+		<SettingsSectionHeading
+			icon="clock"
+			title={$text('reminder.settings.time_heading')}
+		/>
+		<SettingsInput
 			id="settings-reminder-time"
-			class="native-input"
+			dataTestid="settings-reminder-time"
 			type="time"
 			bind:value={time}
 			min={minTime || undefined}
+			ariaLabel={$text('reminder.settings.time_heading')}
 		/>
-	</div>
+	{/if}
 
 	<!-- 7. Repeat? -->
 	<SettingsSectionHeading
@@ -339,13 +412,14 @@
 			title={$text('reminder.panel.repeat_every')}
 		/>
 		<div class="custom-repeat-row">
-			<div class="native-input-wrapper interval-field">
-				<input
+			<div class="interval-field">
+				<SettingsInput
 					id="settings-reminder-interval"
-					class="native-input"
+					dataTestid="settings-reminder-interval"
 					type="number"
 					min="1"
 					bind:value={customInterval}
+					ariaLabel={$text('reminder.panel.repeat_every')}
 				/>
 			</div>
 			<div class="unit-field">
@@ -363,28 +437,29 @@
 			icon="calendar"
 			title={$text('reminder.panel.end_date')}
 		/>
-		<div class="native-input-wrapper">
-			<input
-				id="settings-reminder-end-date"
-				class="native-input"
-				type="date"
-				bind:value={endDate}
-				min={todayStr}
-			/>
-		</div>
+		<SettingsInput
+			id="settings-reminder-end-date"
+			dataTestid="settings-reminder-end-date"
+			type="date"
+			bind:value={endDate}
+			min={todayStr}
+			ariaLabel={$text('reminder.panel.end_date')}
+		/>
 	{/if}
 
 	{#if errorMessage}
 		<SettingsInfoBox type="error">{errorMessage}</SettingsInfoBox>
 	{/if}
 
-	<button
-		data-testid="settings-button-primary"
-		disabled={isSubmitting || !date || !time || (reminderMode === 'new_task' && !actionPrompt.trim())}
-		onclick={handleSubmit}
+	<SettingsButton
+		dataTestid="settings-button-primary"
+		disabled={whenPreset === 'custom' && (!date || !time) || (reminderMode === 'new_task' && !actionPrompt.trim())}
+		loading={isSubmitting}
+		fullWidth
+		onClick={handleSubmit}
 	>
 		{isSubmitting ? $text('reminder.panel.setting') : $text('reminder.settings.create_title')}
-	</button>
+	</SettingsButton>
 </SettingsPageContainer>
 
 <style>
@@ -469,41 +544,6 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-	}
-
-	/* Wrapper to match SettingsDropdown horizontal padding */
-	.native-input-wrapper {
-		padding: 0 0.625rem;
-	}
-
-	/* Native date/time/number inputs styled to match SettingsDropdown */
-	.native-input {
-		width: 100%;
-		padding: 1.0625rem 1.4375rem;
-		background: var(--color-grey-0);
-		border: none;
-		border-radius: 1.5rem;
-		box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.1);
-		font-family:
-			'Lexend Deca Variable',
-			-apple-system,
-			BlinkMacSystemFont,
-			'Segoe UI',
-			Roboto,
-			sans-serif;
-		font-weight: 500;
-		font-size: var(--input-font-size, 1rem);
-		line-height: 1.25;
-		color: var(--color-grey-100);
-		appearance: none;
-		-webkit-appearance: none;
-		transition: box-shadow var(--duration-normal) var(--easing-default);
-		box-sizing: border-box;
-	}
-
-	.native-input:focus {
-		outline: none;
-		box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.15);
 	}
 
 	.custom-repeat-row {

--- a/frontend/packages/ui/src/i18n/sources/demo_chats/announcements_introducing_openmates_v09.yml
+++ b/frontend/packages/ui/src/i18n/sources/demo_chats/announcements_introducing_openmates_v09.yml
@@ -65,7 +65,11 @@ message:
     
     Since then, I've focused completely on improving and debugging OpenMates, and getting it more feature-complete and polished — and made a ton of changes to the code. Bug fixes, new features, an improved user interface, and many more improvements. 
     
-    And today, I'm happy to give you an update with the most exciting changes from the past few months! Keep in mind, talking about all the changes would be too much for a single newsletter — so instead I'll focus on the highlights and also publish multiple short videos about various features on OpenMates in the weeks to come, on [Instagram](https://instagram.com/openmates_official), [Bluesky](https://bsky.app/profile/openmates.bsky.social), [Mastodon](https://mastodon.social/@OpenMates).
+    And today, I'm happy to give you an update with the most exciting changes from the past few months! Keep in mind, talking about all the changes would be too much for a single newsletter — so instead I'll focus on the highlights and also publish multiple short videos about various features on OpenMates in the weeks to come, on:
+    - [Instagram](https://instagram.com/openmates_official)
+    - [Bluesky](https://bsky.app/profile/openmates.bsky.social)
+    - [Mastodon](https://mastodon.social/@OpenMates)
+    - [YouTube](https://www.youtube.com/@OpenMates).
     
     # ✨ The highlights of the last months
     
@@ -144,7 +148,11 @@ message:
     
     Seitdem habe ich mich voll darauf konzentriert OpenMates zu verbessern, zu debuggen und funktional vollständiger und ausgereifter zu machen — und dabei eine Menge am Code verändert. Fehlerbehebungen, neue Funktionen, eine verbesserte Benutzeroberfläche und viele weitere Verbesserungen.
     
-    Und heute freue ich mich, euch ein Update mit den spannendsten Änderungen der letzten Monate zu geben! Alle Änderungen zu besprechen wäre für einen einzelnen Newsletter zu viel — deshalb konzentriere ich mich auf die Highlights und werde in den kommenden Wochen außerdem mehrere kurze Videos zu verschiedenen Funktionen von OpenMates veröffentlichen, auf [Instagram](https://instagram.com/openmates_official), [Bluesky](https://bsky.app/profile/openmates.bsky.social), [Mastodon](https://mastodon.social/@OpenMates).
+    Und heute freue ich mich, euch ein Update mit den spannendsten Änderungen der letzten Monate zu geben! Alle Änderungen zu besprechen wäre für einen einzelnen Newsletter zu viel — deshalb konzentriere ich mich auf die Highlights und werde in den kommenden Wochen außerdem mehrere kurze Videos zu verschiedenen Funktionen von OpenMates veröffentlichen, auf:
+    - [Instagram](https://instagram.com/openmates_official)
+    - [Bluesky](https://bsky.app/profile/openmates.bsky.social)
+    - [Mastodon](https://mastodon.social/@OpenMates)
+    - [YouTube](https://www.youtube.com/@OpenMates).
     
     # ✨ Die Highlights der letzten Monate
     
@@ -247,7 +255,11 @@ email_body:
     
     Since then, I've focused completely on improving and debugging OpenMates, and getting it more feature-complete and polished — and made a ton of changes to the code. Bug fixes, new features, an improved user interface, and many more improvements. 
     
-    And today, I'm happy to give you an update with the most exciting changes from the past few months! Keep in mind, talking about all the changes would be too much for a single newsletter — so instead I'll focus on the highlights and also publish multiple short videos about various features on OpenMates in the weeks to come, on [Instagram](https://instagram.com/openmates_official), [Bluesky](https://bsky.app/profile/openmates.bsky.social), [Mastodon](https://mastodon.social/@OpenMates).
+    And today, I'm happy to give you an update with the most exciting changes from the past few months! Keep in mind, talking about all the changes would be too much for a single newsletter — so instead I'll focus on the highlights and also publish multiple short videos about various features on OpenMates in the weeks to come, on:
+    - [Instagram](https://instagram.com/openmates_official)
+    - [Bluesky](https://bsky.app/profile/openmates.bsky.social)
+    - [Mastodon](https://mastodon.social/@OpenMates)
+    - [YouTube](https://www.youtube.com/@OpenMates).
     
     # ✨ The highlights of the last months
     
@@ -330,7 +342,11 @@ email_body:
     
     Seitdem habe ich mich voll darauf konzentriert OpenMates zu verbessern, zu debuggen und funktional vollständiger und ausgereifter zu machen — und dabei eine Menge am Code verändert. Fehlerbehebungen, neue Funktionen, eine verbesserte Benutzeroberfläche und viele weitere Verbesserungen.
     
-    Und heute freue ich mich, euch ein Update mit den spannendsten Änderungen der letzten Monate zu geben! Alle Änderungen zu besprechen wäre für einen einzelnen Newsletter zu viel — deshalb konzentriere ich mich auf die Highlights und werde in den kommenden Wochen außerdem mehrere kurze Videos zu verschiedenen Funktionen von OpenMates veröffentlichen, auf [Instagram](https://instagram.com/openmates_official), [Bluesky](https://bsky.app/profile/openmates.bsky.social), [Mastodon](https://mastodon.social/@OpenMates).
+    Und heute freue ich mich, euch ein Update mit den spannendsten Änderungen der letzten Monate zu geben! Alle Änderungen zu besprechen wäre für einen einzelnen Newsletter zu viel — deshalb konzentriere ich mich auf die Highlights und werde in den kommenden Wochen außerdem mehrere kurze Videos zu verschiedenen Funktionen von OpenMates veröffentlichen, auf:
+    - [Instagram](https://instagram.com/openmates_official)
+    - [Bluesky](https://bsky.app/profile/openmates.bsky.social)
+    - [Mastodon](https://mastodon.social/@OpenMates)
+    - [YouTube](https://www.youtube.com/@OpenMates).
     
     # ✨ Die Highlights der letzten Monate
     

--- a/frontend/packages/ui/src/i18n/sources/reminder.yml
+++ b/frontend/packages/ui/src/i18n/sources/reminder.yml
@@ -1123,8 +1123,208 @@ settings.type_heading:
   he: סוג תזכורת
   verified_by_human: [en, de]
 
+settings.when_heading:
+  context: Heading label for the quick "When?" preset dropdown in the reminder creation form
+  en: When?
+  de: Wann?
+  zh: 何时？
+  es: ¿Cuándo?
+  fr: Quand ?
+  pt: Quando?
+  ru: Когда?
+  ja: いつ?
+  ko: 언제?
+  it: Quando?
+  tr: Ne zaman?
+  vi: Khi nào?
+  id: Kapan?
+  pl: Kiedy?
+  nl: Wanneer?
+  ar: متى؟
+  hi: कब?
+  th: เมื่อไหร่?
+  cs: Kdy?
+  sv: När?
+  he: מתי?
+  verified_by_human: [en, de]
+
+settings.preset_10min:
+  context: Quick-select option in the When? dropdown — reminder fires 10 minutes from now
+  en: In 10 minutes
+  de: In 10 Minuten
+  zh: 10分钟后
+  es: En 10 minutos
+  fr: Dans 10 minutes
+  pt: Em 10 minutos
+  ru: Через 10 минут
+  ja: 10分後
+  ko: 10분 후
+  it: Fra 10 minuti
+  tr: 10 dakika sonra
+  vi: Sau 10 phút
+  id: Dalam 10 menit
+  pl: Za 10 minut
+  nl: Over 10 minuten
+  ar: بعد 10 دقائق
+  hi: 10 मिनट में
+  th: ใน 10 นาที
+  cs: Za 10 minut
+  sv: Om 10 minuter
+  he: בעוד 10 דקות
+  verified_by_human: [en, de]
+
+settings.preset_30min:
+  context: Quick-select option in the When? dropdown — reminder fires 30 minutes from now
+  en: In 30 minutes
+  de: In 30 Minuten
+  zh: 30分钟后
+  es: En 30 minutos
+  fr: Dans 30 minutes
+  pt: Em 30 minutos
+  ru: Через 30 минут
+  ja: 30分後
+  ko: 30분 후
+  it: Fra 30 minuti
+  tr: 30 dakika sonra
+  vi: Sau 30 phút
+  id: Dalam 30 menit
+  pl: Za 30 minut
+  nl: Over 30 minuten
+  ar: بعد 30 دقيقة
+  hi: 30 मिनट में
+  th: ใน 30 นาที
+  cs: Za 30 minut
+  sv: Om 30 minuter
+  he: בעוד 30 דקות
+  verified_by_human: [en, de]
+
+settings.preset_1hour:
+  context: Quick-select option in the When? dropdown — reminder fires 1 hour from now
+  en: In 1 hour
+  de: In 1 Stunde
+  zh: 1小时后
+  es: En 1 hora
+  fr: Dans 1 heure
+  pt: Em 1 hora
+  ru: Через 1 час
+  ja: 1時間後
+  ko: 1시간 후
+  it: Fra 1 ora
+  tr: 1 saat sonra
+  vi: Sau 1 giờ
+  id: Dalam 1 jam
+  pl: Za 1 godzinę
+  nl: Over 1 uur
+  ar: بعد ساعة واحدة
+  hi: 1 घंटे में
+  th: ใน 1 ชั่วโมง
+  cs: Za 1 hodinu
+  sv: Om 1 timme
+  he: בעוד שעה
+  verified_by_human: [en, de]
+
+settings.preset_today_8pm:
+  context: Quick-select option in the When? dropdown — reminder fires today at 8pm
+  en: Today at 8pm
+  de: Heute um 20:00 Uhr
+  zh: 今天晚上8点
+  es: Hoy a las 8pm
+  fr: Aujourd'hui à 20h
+  pt: Hoje às 20h
+  ru: Сегодня в 20:00
+  ja: 今日の20時
+  ko: 오늘 오후 8시
+  it: Oggi alle 20:00
+  tr: Bugün saat 20:00
+  vi: Hôm nay lúc 20:00
+  id: Hari ini pukul 20:00
+  pl: Dziś o 20:00
+  nl: Vandaag om 20:00
+  ar: اليوم الساعة 8 مساءً
+  hi: आज रात 8 बजे
+  th: วันนี้เวลา 20:00
+  cs: Dnes v 20:00
+  sv: Idag kl. 20:00
+  he: היום בשעה 20:00
+  verified_by_human: [en, de]
+
+settings.preset_tomorrow_9am:
+  context: Quick-select option in the When? dropdown — reminder fires tomorrow at 9am
+  en: Tomorrow at 9am
+  de: Morgen um 9:00 Uhr
+  zh: 明天上午9点
+  es: Mañana a las 9am
+  fr: Demain à 9h
+  pt: Amanhã às 9h
+  ru: Завтра в 9:00
+  ja: 明日の9時
+  ko: 내일 오전 9시
+  it: Domani alle 9:00
+  tr: Yarın saat 9:00
+  vi: Ngày mai lúc 9:00
+  id: Besok pukul 9:00
+  pl: Jutro o 9:00
+  nl: Morgen om 9:00
+  ar: غداً الساعة 9 صباحًا
+  hi: कल सुबह 9 बजे
+  th: พรุ่งนี้เวลา 9:00
+  cs: Zítra v 9:00
+  sv: Imorgon kl. 9:00
+  he: מחר בשעה 9:00
+  verified_by_human: [en, de]
+
+settings.preset_saturday_11am:
+  context: Quick-select option in the When? dropdown — reminder fires on the coming Saturday at 11am
+  en: Saturday at 11am
+  de: Samstag um 11:00 Uhr
+  zh: 周六上午11点
+  es: El sábado a las 11am
+  fr: Samedi à 11h
+  pt: Sábado às 11h
+  ru: В субботу в 11:00
+  ja: 土曜日の11時
+  ko: 토요일 오전 11시
+  it: Sabato alle 11:00
+  tr: Cumartesi saat 11:00
+  vi: Thứ Bảy lúc 11:00
+  id: Sabtu pukul 11:00
+  pl: W sobotę o 11:00
+  nl: Zaterdag om 11:00
+  ar: السبت الساعة 11 صباحًا
+  hi: शनिवार को सुबह 11 बजे
+  th: วันเสาร์เวลา 11:00
+  cs: V sobotu v 11:00
+  sv: Lördag kl. 11:00
+  he: שבת בשעה 11:00
+  verified_by_human: [en, de]
+
+settings.preset_custom:
+  context: Quick-select option in the When? dropdown — user picks a custom date and time
+  en: Custom
+  de: Benutzerdefiniert
+  zh: 自定义
+  es: Personalizado
+  fr: Personnalisé
+  pt: Personalizado
+  ru: Произвольно
+  ja: カスタム
+  ko: 직접 입력
+  it: Personalizzato
+  tr: Özel
+  vi: Tùy chỉnh
+  id: Kustom
+  pl: Niestandardowy
+  nl: Aangepast
+  ar: مخصص
+  hi: कस्टम
+  th: กำหนดเอง
+  cs: Vlastní
+  sv: Anpassad
+  he: מותאם אישית
+  verified_by_human: [en, de]
+
 settings.day_heading:
-  context: Heading label for the day/date picker field
+  context: Heading label for the day/date picker field (shown only when Custom is selected)
   en: Day?
   de: Tag?
   zh: 哪天？


### PR DESCRIPTION
## Summary

This PR adds a quick When? preset dropdown to the reminder UI (replacing static Day/Time fields), introduces a new `publish-newsletter` Claude Code skill, and fixes two minor issues (CORS for reminder routes and an aiohttp header size limit in newsletter validation).

## Features

- **Reminder quick presets:** Replaced static Day? / Time? input fields with a contextual When? dropdown offering preset durations (in 10 min, in 30 min, in 1 hr, etc.). Custom is still available and reveals the original Day/Time pickers. Improves the one-tap reminder flow.
- **publish-newsletter skill:** New `.claude/skills/publish-newsletter` skill wraps `publish_newsletter.py` + translation rebuild + deploy + optional test-send. Makes newsletter publishing a single `/publish-newsletter` command.

## Bug Fixes

- **CORS for reminder skills:** Routes `/v1/apps/reminder/skills/*` were hitting the wildcard CORS handler instead of the authenticated matcher. Added explicit matchers in `Caddyfile`.
- **Newsletter aiohttp header limit:** Increased the header size limit to prevent failures when validating landing page URLs with large response headers.

## Other Changes

- Re-published `introducing-openmates-v09` announcement with a YouTube channel link added to the body.
- Added Apple UI redesign task doc to `.claude/frontend/`.
- Updated reminder i18n sources with new preset labels.