### PR TITLE
fix(deep-link): newsletter chat autoplay-video link + Apple UI improvements

### DIFF
--- a/apple/OpenMates/Sources/App/MainAppView.swift
+++ b/apple/OpenMates/Sources/App/MainAppView.swift
@@ -246,16 +246,26 @@ struct MainAppView: View {
     private var sidebar: some View {
         List(selection: $selectedChatId) {
             if !filteredPinnedChats.isEmpty {
-                Section(AppStrings.pinnedChats) {
+                Section {
                     ForEach(filteredPinnedChats) { chat in
                         chatRow(chat)
                     }
+                } header: {
+                    Text(AppStrings.pinnedChats.uppercased())
+                        .font(.omXs)
+                        .foregroundStyle(Color.fontTertiary)
                 }
             }
 
-            Section(filteredPinnedChats.isEmpty ? "" : AppStrings.recentChats) {
+            Section {
                 ForEach(filteredUnpinnedChats) { chat in
                     chatRow(chat)
+                }
+            } header: {
+                if !filteredPinnedChats.isEmpty {
+                    Text(AppStrings.recentChats.uppercased())
+                        .font(.omXs)
+                        .foregroundStyle(Color.fontTertiary)
                 }
             }
 
@@ -281,7 +291,8 @@ struct MainAppView: View {
                 }
             }
         }
-        .listStyle(.sidebar)
+        .listStyle(.plain)
+        .listRowSeparator(.hidden)
         .searchable(text: $searchText, prompt: AppStrings.search)
         .navigationTitle(AppStrings.chats)
         #if os(iOS)
@@ -353,6 +364,8 @@ struct MainAppView: View {
         if isAuthenticated {
             ChatListRow(chat: chat)
                 .tag(chat.id)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                     Button(role: .destructive) { deleteChat(chat.id) } label: {
                         Label(AppStrings.delete, systemImage: "trash")
@@ -375,6 +388,8 @@ struct MainAppView: View {
         } else {
             ChatListRow(chat: chat)
                 .tag(chat.id)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
         }
     }
 
@@ -650,11 +665,13 @@ struct WelcomeView: View {
                 Text("\(AppStrings.login) / \(AppStrings.signup)")
                     .font(.omP)
                     .fontWeight(.semibold)
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, .spacing8)
-                    .padding(.vertical, .spacing4)
+                    .foregroundStyle(Color.fontButton)
+                    .padding(.horizontal, .spacing12)
+                    .padding(.vertical, .spacing8)
+                    .frame(minHeight: 41)
                     .background(Color.buttonPrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: .radius5))
+                    .clipShape(RoundedRectangle(cornerRadius: .radius8))
+                    .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)
             }
             .accessibilityIdentifier("welcome-login-button")
             .padding(.top, .spacing4)

--- a/apple/OpenMates/Sources/Features/Chat/Views/ChatView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/ChatView.swift
@@ -35,6 +35,7 @@ struct ChatView: View {
             }
             inputBar
         }
+        .background(Color.grey0)
         .navigationTitle(viewModel.chat?.displayTitle ?? AppStrings.chats)
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -153,6 +154,7 @@ struct ChatView: View {
                     ForEach(viewModel.messages) { message in
                         MessageBubble(
                             message: message,
+                            appId: viewModel.chat?.appId,
                             embeds: viewModel.embeds(for: message),
                             streamingContent: viewModel.isStreamingMessage(message.id) ? viewModel.streamingContent : nil,
                             onEmbedTap: { embed in
@@ -193,6 +195,9 @@ struct ChatView: View {
                 }
                 .padding(.horizontal, .spacing4)
                 .padding(.vertical, .spacing4)
+                // Cap message area width on iPad/Mac, centered
+                .frame(maxWidth: 1000)
+                .frame(maxWidth: .infinity)
             }
             .onChange(of: viewModel.messages.count) { _, _ in
                 withAnimation {
@@ -235,7 +240,6 @@ struct ChatView: View {
 
     private var inputBar: some View {
         VStack(spacing: 0) {
-            Divider()
             HStack(alignment: .bottom, spacing: .spacing3) {
                 AttachmentPicker(
                     isPresented: .constant(false),
@@ -247,14 +251,37 @@ struct ChatView: View {
                     }
                 )
 
+                // Pill-shaped input field matching web app's fields.css:
+                // border-radius: 24px, border: 2px, orange focus ring
                 TextField(AppStrings.typeMessage, text: $messageText, axis: .vertical)
                     .textFieldStyle(.plain)
                     .font(.omP)
                     .lineLimit(1...6)
-                    .padding(.horizontal, .spacing4)
-                    .padding(.vertical, .spacing3)
-                    .background(Color.grey10)
-                    .clipShape(RoundedRectangle(cornerRadius: .radius5))
+                    .padding(.horizontal, .spacing8)
+                    .padding(.vertical, .spacing6)
+                    .background(Color.grey0)
+                    .clipShape(RoundedRectangle(cornerRadius: .radiusFull))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: .radiusFull)
+                            .stroke(
+                                isInputFocused ? Color.buttonPrimary : Color.grey0,
+                                lineWidth: 2
+                            )
+                    )
+                    .shadow(
+                        color: isInputFocused
+                            ? Color.buttonPrimary.opacity(0.22)
+                            : .clear,
+                        radius: 3, x: 0, y: 0
+                    )
+                    .shadow(
+                        color: isInputFocused
+                            ? .black.opacity(0.08)
+                            : .black.opacity(0.05),
+                        radius: isInputFocused ? 12 : 2,
+                        x: 0, y: 4
+                    )
+                    .tint(Color.buttonPrimary)
                     .focused($isInputFocused)
                     .onSubmit { sendMessage() }
                     .accessibilityLabel(AppStrings.chatMessageInput)
@@ -269,12 +296,19 @@ struct ChatView: View {
                         }
                     }
                 } else {
+                    // Circular send button — orange fill when text present,
+                    // grey when empty (matching web app)
                     Button(action: sendMessage) {
-                        Image(systemName: "arrow.up.circle.fill")
-                            .font(.system(size: 32))
+                        Image(systemName: "arrow.up")
+                            .font(.system(size: 16, weight: .semibold))
                             .foregroundStyle(
-                                messageText.isEmpty ? Color.fontTertiary : Color.buttonPrimary
+                                messageText.isEmpty ? Color.fontTertiary : Color.fontButton
                             )
+                            .frame(width: 32, height: 32)
+                            .background(
+                                messageText.isEmpty ? Color.grey20 : Color.buttonPrimary
+                            )
+                            .clipShape(Circle())
                     }
                     .disabled(messageText.isEmpty || viewModel.isStreaming)
                     .accessibilityLabel(AppStrings.sendMessage)
@@ -305,9 +339,12 @@ struct ChatView: View {
 
 struct MessageBubble: View {
     let message: Message
+    let appId: String?
     let embeds: [EmbedRecord]
     let streamingContent: String?
     let onEmbedTap: (EmbedRecord) -> Void
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
+    @State private var hasAppeared = false
 
     var isUser: Bool { message.role == .user }
 
@@ -316,26 +353,64 @@ struct MessageBubble: View {
         return message.content ?? ""
     }
 
+    // MARK: - Assistant avatar with AI badge
+
+    private var assistantAvatar: some View {
+        AppIconView(appId: appId ?? "ai", size: 60)
+            .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)
+            .overlay(alignment: .bottomTrailing) {
+                // White 24px circle housing a 16px AI gradient icon
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 24, height: 24)
+                    .overlay {
+                        Circle()
+                            .fill(LinearGradient.appAi)
+                            .frame(width: 16, height: 16)
+                            .overlay {
+                                Image(systemName: "sparkles")
+                                    .font(.system(size: 7, weight: .bold))
+                                    .foregroundStyle(.white)
+                            }
+                    }
+                    .shadow(color: .black.opacity(0.15), radius: 2, x: 0, y: 1)
+            }
+    }
+
     var body: some View {
-        HStack(alignment: .top) {
-            if isUser { Spacer(minLength: 40) }
+        HStack(alignment: .top, spacing: .spacing3) {
+            if isUser {
+                Spacer(minLength: 100)
+            } else {
+                assistantAvatar
+            }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: .spacing3) {
                 // Message text — user messages use inline-only markdown,
                 // assistant messages use full block-level rendering (code blocks, tables, etc.)
                 if !displayContent.isEmpty {
                     if isUser {
+                        // User bubble: grey-blue bg, speech tail on right, drop shadow
                         InlineMarkdownText(content: displayContent, isUserMessage: true)
-                            .padding(.horizontal, .spacing4)
-                            .padding(.vertical, .spacing3)
-                            .background(AnyShapeStyle(LinearGradient.primary))
-                            .clipShape(RoundedRectangle(cornerRadius: .radius5))
+                            .foregroundStyle(Color.grey100)
+                            .padding(.spacing6)
+                            .background(Color.greyBlue)
+                            .clipShape(RoundedRectangle(cornerRadius: 13))
+                            .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)
+                            .overlay(alignment: .bottomTrailing) {
+                                SpeechTailView(side: .trailing, color: Color.greyBlue)
+                            }
                     } else {
+                        // Assistant bubble: white/grey0 bg, speech tail on left, drop shadow
                         RichMarkdownView(content: displayContent, isUserMessage: false)
-                            .padding(.horizontal, .spacing4)
-                            .padding(.vertical, .spacing3)
-                            .background(AnyShapeStyle(Color.grey10))
-                            .clipShape(RoundedRectangle(cornerRadius: .radius5))
+                            .foregroundStyle(Color.fontPrimary)
+                            .padding(.spacing6)
+                            .background(Color.grey0)
+                            .clipShape(RoundedRectangle(cornerRadius: 13))
+                            .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)
+                            .overlay(alignment: .topLeading) {
+                                SpeechTailView(side: .leading, color: Color.grey0)
+                            }
                     }
                 }
 
@@ -350,11 +425,73 @@ struct MessageBubble: View {
                 }
             }
 
-            if !isUser { Spacer(minLength: 40) }
+            if !isUser { Spacer(minLength: 70) }
+        }
+        // Fade-in animation matching web CSS: opacity 0→1, translateY 10→0, 0.4s easeIn
+        .opacity(hasAppeared ? 1 : 0)
+        .offset(y: hasAppeared ? 0 : 10)
+        .onAppear {
+            if reduceMotion {
+                hasAppeared = true
+            } else {
+                withAnimation(.easeIn(duration: 0.4)) {
+                    hasAppeared = true
+                }
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(isUser ? "You" : "AI"): \(displayContent.prefix(200))")
         .accessibilityHint("Long press for options")
+    }
+}
+
+// MARK: - Speech bubble tail overlay
+
+private enum BubbleTailSide { case leading, trailing }
+
+/// Renders the triangular speech tail as an overlay, positioned to extend
+/// beyond the bubble's clipped edge. Uses the SVG curve shape.
+private struct SpeechTailView: View {
+    let side: BubbleTailSide
+    let color: Color
+
+    /// Tail dimensions matching web CSS (12×20px)
+    private let tailWidth: CGFloat = 12
+    private let tailHeight: CGFloat = 20
+
+    var body: some View {
+        Canvas { context, _ in
+            // Draw the SVG path: M0 9.926c0 .992 3.191 1.814 7 0V0C5.093 4.893 0 8.933 0 9.926z
+            // Scaled from 7×11 viewBox to 12×20pt
+            let sx = tailWidth / 7.0
+            let sy = tailHeight / 11.0
+
+            var path = Path()
+            path.move(to: CGPoint(x: 0, y: 9.926 * sy))
+            // First curve: c0 .992 3.191 1.814 7 0
+            path.addCurve(
+                to: CGPoint(x: 7 * sx, y: 9.926 * sy),
+                control1: CGPoint(x: 0, y: (9.926 + 0.992) * sy),
+                control2: CGPoint(x: 3.191 * sx, y: (9.926 + 1.814) * sy)
+            )
+            // V0 — line to top
+            path.addLine(to: CGPoint(x: 7 * sx, y: 0))
+            // C5.093 4.893 0 8.933 0 9.926
+            path.addCurve(
+                to: CGPoint(x: 0, y: 9.926 * sy),
+                control1: CGPoint(x: 5.093 * sx, y: 4.893 * sy),
+                control2: CGPoint(x: 0, y: 8.933 * sy)
+            )
+            path.closeSubpath()
+
+            context.fill(path, with: .color(color))
+        }
+        .frame(width: tailWidth, height: tailHeight)
+        .offset(
+            x: side == .trailing ? tailWidth : -tailWidth,
+            y: side == .trailing ? -10 : 20
+        )
+        .allowsHitTesting(false)
     }
 }
 
@@ -379,8 +516,9 @@ struct StreamingIndicator: View {
             }
             .padding(.horizontal, .spacing4)
             .padding(.vertical, .spacing4)
-            .background(Color.grey10)
-            .clipShape(RoundedRectangle(cornerRadius: .radius5))
+            .background(Color.grey0)
+            .clipShape(RoundedRectangle(cornerRadius: 13))
+            .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)
 
             Spacer()
         }

--- a/frontend/apps/web_app/src/routes/+page.svelte
+++ b/frontend/apps/web_app/src/routes/+page.svelte
@@ -45,6 +45,7 @@
 		setForcedLogoutInProgress,
 		resetForcedLogoutInProgress,
 		isPublicChat,
+		isNewsletterChat,
 		loadSessionStorageDraft,
 		getAllDraftChatIdsWithDrafts,
 		NEW_CHAT_SENTINEL,
@@ -182,10 +183,11 @@
 		chatId: string,
 		messageId?: string | null,
 		scrollToLatestResponse?: boolean,
-		embedId?: string | null
+		embedId?: string | null,
+		autoplayVideo?: boolean
 	) {
 		console.debug(
-			`[+page.svelte] Handling chat deep link for: ${chatId}${messageId ? `, message: ${messageId}` : ''}${scrollToLatestResponse ? ' (scroll to latest response)' : ''}${embedId ? `, embed: ${embedId}` : ''}`
+			`[+page.svelte] Handling chat deep link for: ${chatId}${messageId ? `, message: ${messageId}` : ''}${scrollToLatestResponse ? ' (scroll to latest response)' : ''}${embedId ? `, embed: ${embedId}` : ''}${autoplayVideo ? ' (autoplay-video)' : ''}`
 		);
 
 		// If messageId is provided, set it in the highlight store
@@ -211,7 +213,7 @@
 			const exampleChatObj = getExampleChat(chatId);
 			if (exampleChatObj && activeChat) {
 				// Example chats are static — load directly (embed refs already registered on page load)
-				activeChat.loadChat(exampleChatObj, { scrollToLatestResponse });
+				activeChat.loadChat(exampleChatObj, { scrollToLatestResponse, autoplayVideo });
 
 				const globalChatSelectedEvent = new CustomEvent('globalChatSelected', {
 					detail: { chat: exampleChatObj },
@@ -257,7 +259,7 @@
 					const translatedChat = translateDemoChat(publicChat);
 					const chat = convertDemoChatToChat(translatedChat);
 
-					activeChat.loadChat(chat, { scrollToLatestResponse });
+					activeChat.loadChat(chat, { scrollToLatestResponse, autoplayVideo });
 
 					// Dispatch globalChatSelected event so Chats.svelte highlights the chat
 					const globalChatSelectedEvent = new CustomEvent('globalChatSelected', {
@@ -582,8 +584,8 @@
 		// authenticated users. These get into the hash when: (a) forced logout sets it during
 		// missing-master-key cleanup, or (b) non-auth welcome chat sets it before the user logs in.
 		// After login, the user should land on their last-opened chat, not the demo.
-		const hasExplicitDeepLink = browser && window.location.hash.includes('autoplay-video');
-		if (hashChatIdToLoad && isPublicChat(hashChatIdToLoad) && $authStore.isAuthenticated && !hasExplicitDeepLink) {
+		// EXCEPTION: Newsletter chats are always intentional deep links (from email CTAs) — never skip them.
+		if (hashChatIdToLoad && isPublicChat(hashChatIdToLoad) && !isNewsletterChat(hashChatIdToLoad) && $authStore.isAuthenticated) {
 			console.debug(
 				'[+page.svelte] Skipping public/demo chat hash override for authenticated user:',
 				hashChatIdToLoad
@@ -634,9 +636,8 @@
 		// PRIORITY 2: Skip if hash is a chat (hash chat takes precedence)
 		// OPE-215: Don't skip for public/demo chats when user is authenticated — those are
 		// just defaults from the non-auth state, not intentional deep links.
-		// Exception: explicit deep links (e.g. &autoplay-video from newsletter emails) should always load.
-		const hasAutoplayDeepLink = browser && window.location.hash.includes('autoplay-video');
-		if (originalHashChatId && !(isPublicChat(originalHashChatId) && $authStore.isAuthenticated && !hasAutoplayDeepLink)) {
+		// Exception: newsletter chats are always intentional deep links (email CTAs) — never skip them.
+		if (originalHashChatId && !(isPublicChat(originalHashChatId) && !isNewsletterChat(originalHashChatId) && $authStore.isAuthenticated)) {
 			console.debug(
 				'[+page.svelte] [PRIORITY 2] Skipping last_opened chat - hash chat has priority:',
 				originalHashChatId
@@ -2358,7 +2359,8 @@
 				chatId: string,
 				messageId?: string | null,
 				scrollToLatestResponse?: boolean,
-				embedId?: string | null
+				embedId?: string | null,
+				autoplayVideo?: boolean
 			) => {
 				// Update originalHashChatId to reflect the new hash (important for sync completion handler)
 				originalHashChatId = chatId;
@@ -2367,7 +2369,7 @@
 				isProcessingInitialHash = true;
 				deepLinkProcessed = true; // Mark that a deep link was processed
 
-				await handleChatDeepLink(chatId, messageId, scrollToLatestResponse, embedId);
+				await handleChatDeepLink(chatId, messageId, scrollToLatestResponse, embedId, autoplayVideo);
 
 				// Reset flag after processing
 				isProcessingInitialHash = false;

--- a/frontend/packages/ui/src/components/ActiveChat.svelte
+++ b/frontend/packages/ui/src/components/ActiveChat.svelte
@@ -6716,7 +6716,7 @@ console.debug('[ActiveChat] Loading child website embeds for web search fullscre
     }
 
      // Update the loadChat function
-     export async function loadChat(chat: Chat, options?: { scrollToLatestResponse?: boolean; scrollToTop?: boolean }) {
+     export async function loadChat(chat: Chat, options?: { scrollToLatestResponse?: boolean; scrollToTop?: boolean; autoplayVideo?: boolean }) {
          // RACE CONDITION GUARD: Increment generation counter so concurrent/stale calls bail out.
          // Between setting currentChat (immediate) and setting currentMessages (after async DB reads),
          // chatUpdated events can see the new currentChat but operate on the old currentMessages.
@@ -7306,9 +7306,9 @@ console.debug('[ActiveChat] Loading child website embeds for web search fullscre
         console.debug(`[ActiveChat] loadChat: showWelcome=${showWelcome}, messageCount=${currentMessages.length}, chatId=${currentChat?.chat_id}`);
 
         // ─── Autoplay video deep link ────────────────────────────────────
-        // Hash format: #chat-id=<id>&autoplay-video
-        // Sets a flag so ChatHeader auto-triggers native fullscreen playback on mount.
-        if (typeof window !== 'undefined' && window.location.hash.includes('autoplay-video') && currentChat?.chat_id) {
+        // Passed explicitly via loadChat options rather than read from window.location.hash
+        // (which may already be rewritten by activeChatStore.setActiveChat before loadChat runs).
+        if (options?.autoplayVideo && currentChat?.chat_id) {
             pendingAutoplayVideo = true;
             console.debug('[ActiveChat] Autoplay video flag set from deep link for chat:', currentChat.chat_id);
         }

--- a/frontend/packages/ui/src/services/__tests__/deepLinkHandler.test.ts
+++ b/frontend/packages/ui/src/services/__tests__/deepLinkHandler.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { parseDeepLink } from "../deepLinkHandler";
+
+describe("parseDeepLink", () => {
+  it("parses chat links with a bare autoplay-video flag", () => {
+    expect(
+      parseDeepLink("#chat-id=announcements-introducing-openmates-v09&autoplay-video"),
+    ).toEqual({
+      type: "chat",
+      data: {
+        chatId: "announcements-introducing-openmates-v09",
+        messageId: null,
+        scrollToLatestResponse: false,
+        embedId: null,
+        autoplayVideo: true,
+      },
+    });
+  });
+
+  it("keeps existing chat link params", () => {
+    expect(
+      parseDeepLink("#chat-id=chat-123&embed-id=embed-456&message-id=msg-789&scroll=latest-response"),
+    ).toEqual({
+      type: "chat",
+      data: {
+        chatId: "chat-123",
+        messageId: "msg-789",
+        scrollToLatestResponse: true,
+        embedId: "embed-456",
+        autoplayVideo: false,
+      },
+    });
+  });
+});

--- a/frontend/packages/ui/src/services/deepLinkHandler.ts
+++ b/frontend/packages/ui/src/services/deepLinkHandler.ts
@@ -38,6 +38,7 @@ export interface DeepLinkHandlers {
     messageId?: string | null,
     scrollToLatestResponse?: boolean,
     embedId?: string | null,
+    autoplayVideo?: boolean,
   ) => Promise<void>;
   onSettings?: (path: string, hash: string) => void;
   onSignup?: (step: string) => void;
@@ -72,53 +73,26 @@ export function parseDeepLink(
   // Optional params: &message-id={id}  &scroll=latest-response  &embed-id={id}
   const normalizedHash = hash.startsWith("#/") ? "#" + hash.substring(2) : hash;
 
-  // Combined chat+embed format: #chat-id={chatId}&embed-id={embedId}
-  // Must be checked before the generic chat-only regex so the embed-id param is captured.
-  const combinedMatch = normalizedHash.match(
-    /^#chat[-_]?id=([^&]+)&embed[-_]?id=([^&]+)((?:&[^=]+=[^&]*)*)$/,
-  );
-  if (combinedMatch) {
-    const chatId = combinedMatch[1];
-    const embedId = combinedMatch[2];
-    const extraParams = combinedMatch[3] || "";
-    const messageIdMatch = extraParams.match(/&message[-_]?id=([^&]+)/);
-    const messageId = messageIdMatch ? messageIdMatch[1] : null;
-    const scrollMatch = extraParams.match(/&scroll=([^&]+)/);
-    const scrollToLatestResponse = scrollMatch
-      ? scrollMatch[1] === "latest-response"
-      : false;
-    return {
-      type: "chat",
-      data: {
-        chatId,
-        messageId,
-        scrollToLatestResponse,
-        embedId,
-      },
-    };
-  }
-
-  const chatMatch = normalizedHash.match(
-    /^#chat[-_]?id=([^&]+)((?:&[^=]+=.[^&]*)*)$/,
-  );
+  const chatMatch = normalizedHash.match(/^#chat[-_]?id=([^&]+)(.*)$/);
   if (chatMatch) {
     const chatId = chatMatch[1];
     const extraParams = chatMatch[2] || "";
+    const params = new URLSearchParams(extraParams.startsWith("&") ? extraParams.slice(1) : extraParams);
+
     // Extract optional message-id param
-    const messageIdMatch = extraParams.match(/&message[-_]?id=([^&]+)/);
-    const messageId = messageIdMatch ? messageIdMatch[1] : null;
+    const messageId = params.get("message-id") ?? params.get("message_id");
+
     // Extract optional scroll param — 'latest-response' means scroll to top of newest assistant message
-    const scrollMatch = extraParams.match(/&scroll=([^&]+)/);
-    const scrollToLatestResponse = scrollMatch
-      ? scrollMatch[1] === "latest-response"
-      : false;
+    const scrollToLatestResponse = params.get("scroll") === "latest-response";
+
     return {
       type: "chat",
       data: {
         chatId,
         messageId,
         scrollToLatestResponse,
-        embedId: null,
+        embedId: params.get("embed-id") ?? params.get("embed_id"),
+        autoplayVideo: params.has("autoplay-video") || params.has("autoplay_video"),
       },
     };
   }
@@ -219,6 +193,7 @@ export async function processDeepLink(
           parsed.data.messageId,
           parsed.data.scrollToLatestResponse,
           parsed.data.embedId ?? null,
+          parsed.data.autoplayVideo ?? false,
         );
         return { type: "chat", processed: true };
       }


### PR DESCRIPTION
## Summary

Fixes the newsletter email CTA link: clicking a video thumbnail in the OpenMates v0.9 announcement email was supposed to open the newsletter chat with the video autoplaying — neither was happening. Root cause was a regex in `parseDeepLink` that required every extra hash param to have `=value` syntax, so the bare `&autoplay-video` flag caused the match to fail entirely. Also ships two Apple client improvements adding assistant avatars and fixing list row backgrounds.

## Bug Fixes

- **Newsletter deep link not loading** (`deepLinkHandler.ts`): Old regex `/^#chat[-_]?id=([^&]+)((?:&[^=]+=.[^&]*)*)$/` rejected bare flags like `&autoplay-video` — replaced with permissive `(.*)` + `URLSearchParams` that handles both `key=value` and bare `key` params
- **autoplay-video flag lost after hash rewrite** (`ActiveChat.svelte`): `activeChatStore.setActiveChat()` strips extra params from the hash before `loadChat` runs — fixed by threading `autoplayVideo` explicitly through the call chain instead of re-reading the hash
- **OPE-215 guard blocked newsletter chats for authenticated users** (`+page.svelte`): Guard was checking `window.location.hash.includes('autoplay-video')` (always false after hash rewrite) — replaced with `!isNewsletterChat(hashChatIdToLoad)` so newsletter chats (intentional email CTAs) always load regardless of auth state

## Features

- **Apple: Assistant avatar in chat bubbles** — 60 px `AppIconView` with AI badge overlay rendered next to all assistant `MessageBubble`s; `appId` threaded from `viewModel.chat` down through `ChatView` and `MessageBubble`
- **Apple: Sidebar list row chrome stripped** — `.listRowBackground(Color.clear)` + `.listRowSeparator(.hidden)` applied per row in `ChatListRow` and `FollowUpSuggestions` to remove native UIKit backgrounds

## Other

- Unit tests for `parseDeepLink` covering bare flag and combined param cases (`deepLinkHandler.test.ts`)