### PR TITLE
feat: SEO semantic URLs, signup CTA redesign, Apple UI parity & fixes

### DIFF
--- a/.claude/rules/apple-ui.md
+++ b/.claude/rules/apple-ui.md
@@ -1,0 +1,122 @@
+# Apple UI — Web Source of Truth
+
+Every Swift UI file must visually match its web counterpart exactly.
+The web app (Svelte + CSS custom properties) is the design source of truth.
+Design tokens are pre-generated — never hardcode colors, spacing, or radii.
+
+---
+
+## Mandatory: Web-Source Comment Block
+
+Every `.swift` file under `apple/OpenMates/Sources/` with visual output MUST
+have this block immediately after the file-level header comment:
+
+```swift
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/ChatMessage.svelte
+// CSS:     frontend/packages/ui/src/styles/chat.css
+//          Classes: .mate-message-content, .user-message-content::before
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+```
+
+Include only the files that directly drive the visual spec for that view.
+Multiple Svelte files or CSS files are fine — list all that apply.
+
+---
+
+## Canonical File ↔ Web Mapping
+
+| Swift file | Svelte source | CSS source |
+|---|---|---|
+| `ChatView.swift` — `MessageBubble` | `components/ChatMessage.svelte` | `styles/chat.css` — `.mate-message-content`, `.user-message-content`, `::before` tails |
+| `ChatView.swift` — `inputBar` | `components/enter_message/MessageInput.svelte` | `styles/fields.css` |
+| `ChatView.swift` — `StreamingIndicator` | `components/ChatHistory.svelte` (typing indicator) | `styles/chat.css` |
+| `ChatView.swift` — `messageList` | `components/ChatHistory.svelte` | `styles/chat.css` — `.chat-history-content`, max-width 1000px |
+| `ChatHeaderView.swift` | `components/ChatHeader.svelte` | — (gradient from `GradientTokens.generated.swift`) |
+| `ChatListRow.swift` | `components/chats/Chat.svelte` | — |
+| `MainAppView.swift` — sidebar | `components/ChatHistory.svelte`, `components/Header.svelte` | — |
+| `OMButtonStyles.swift` | — | `styles/buttons.css` |
+| `FollowUpSuggestions.swift` | `components/FollowUpSuggestions.svelte` | `styles/chat.css` — `.follow-up-suggestions-wrapper` |
+| `NewChatBannerView.swift` | `components/ChatHeader.svelte` | — (gradient from `GradientTokens.generated.swift`) |
+| `SpeechBubbleShape.swift` | — | `styles/chat.css` — `::before` SVG mask, `static/speechbubble.svg` |
+
+---
+
+## Design Rules (must follow before writing any Swift UI code)
+
+### Before touching any Swift UI file
+1. Read the mapped Svelte component listed above.
+2. Read the mapped CSS file — note exact class names, pixel values, transitions.
+3. Read the token mapping table in `docs/architecture/frontend/apple-ui-redesign-task.md`.
+4. Only then write or modify Swift code.
+
+### Colors — never hardcode
+- Use `Color.*` extensions from `ColorTokens.generated.swift`.
+- Use `LinearGradient.*` extensions from `GradientTokens.generated.swift`.
+- No `Color(hex:)`, no `Color(.sRGB, r:g:b:)`, no `Color("name")` without a token.
+
+### Spacing & radius — never hardcode (with one exception)
+- Use `.spacingN` / `.radiusN` from `SpacingTokens.generated.swift`.
+- Exception: message bubble corner radius is exactly `13` (not a token) — matches
+  `border-radius: 13px` in `chat.css`.
+
+### Typography — never hardcode
+- Use `Font.omH1` … `Font.omMicro` from `TypographyTokens.generated.swift`.
+- Never `Font.system(size:)` for text that appears in the UI.
+
+### Native chrome — strip it
+- `NavigationSplitView` sidebar: always `.listStyle(.plain)` +
+  `.listRowBackground(Color.clear)` + `.listRowSeparator(.hidden)`.
+- No `List(.sidebar)` styling.
+- Sidebar column background: `.background(Color.grey0)`.
+
+### Message bubbles (from `chat.css`)
+- User bubble: `Color.greyBlue` background, `Color.grey100` text, tail bottom-right.
+- Assistant bubble: `Color.grey0` background, `Color.fontPrimary` text, tail top-left.
+- Both: `shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)`.
+- `clipShape(RoundedRectangle(cornerRadius: 13))`.
+- Fade-in: `opacity(0→1)` + `offset(y: 10→0)` over 0.4s `.easeIn`. Respect `accessibilityReduceMotion`.
+- Assistant avatar: 60pt circle, same shadow. AI badge: 24pt white circle, 16pt gradient icon inside.
+- Max width: `Spacer(minLength: 100)` on iPhone, `Spacer(minLength: 100)` on iPad/Mac (content capped at 1000pt).
+
+### Input field (from `fields.css`)
+- Shape: `.clipShape(RoundedRectangle(cornerRadius: .radiusFull))`.
+- Border: 2pt stroke, `Color.grey0` default → `Color.buttonPrimary` when focused.
+- Focus glow: `shadow(color: Color.buttonPrimary.opacity(0.22), radius: 3, x:0, y:0)` +
+  `shadow(color: .black.opacity(0.08), radius: 12, x:0, y:4)`.
+- Tint: `.tint(Color.buttonPrimary)`.
+- Send button: circle, `Color.buttonPrimary` fill when text present, `Color.grey20` when empty.
+- Apply consistently — not just in `ChatView.inputBar` but in `NewChatView` too.
+
+### Buttons (from `buttons.css`)
+- Shape: `RoundedRectangle(cornerRadius: .radius8)` — `radius8` = 20pt.
+- Padding: `.spacing12` horizontal, `.spacing8` vertical. Min height 41pt.
+- Font: `.omP` semibold.
+- Primary fill: `Color.buttonPrimary`. Text: `Color.fontButton`.
+- Shadow: `shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)`.
+- Press: scale 0.98, 0.15s easeInOut. Disabled: opacity 0.6.
+
+### Follow-up suggestions (from `chat.css` `.follow-up-suggestions-wrapper`)
+- `clipShape(RoundedRectangle(cornerRadius: .radiusFull))`.
+- Background `Color.grey10`, border `Color.grey30` (1pt stroke).
+- Font `.omSmall` medium, `Color.fontPrimary`.
+- Padding `.spacing6` H, `.spacing3` V.
+- Horizontal `ScrollView`.
+
+### Speech bubble tail (from `speechbubble.svg` + `chat.css ::before`)
+- SVG viewBox 7×11 → rendered 12×20pt.
+- User message: tail on bottom-trailing, `Color.greyBlue` fill.
+- Assistant message: tail on top-leading, `Color.grey0` fill.
+- Implemented as `Canvas` overlay in `SpeechBubbleShape.swift` (separate file).
+
+---
+
+## What NOT to change
+- Business logic, networking, WebSocket, encryption (`Core/` directory).
+- Navigation flow or sheets.
+- Generated token files (`*.generated.swift`).
+- Siri Intents, Spotlight, Handoff, widget code.
+- Settings screen (separate task).
+- Accessibility labels and identifiers — preserve or update when view hierarchy changes.
+- `.task {}`, `.onReceive {}`, `.onChange {}`, `.sheet {}` modifiers in `MainAppView`.

--- a/.claude/rules/apple-ui.md
+++ b/.claude/rules/apple-ui.md
@@ -6,6 +6,52 @@ Design tokens are pre-generated — never hardcode colors, spacing, or radii.
 
 ---
 
+## CRITICAL: No Hardcoded Strings — Ever
+
+**Every user-visible string MUST go through `AppStrings` or `LocalizationManager`.**
+Hardcoding English text in Swift files is a bug, not a shortcut.
+
+### The chain
+```
+i18n YML source files  (frontend/packages/ui/src/i18n/sources/**/*.yml)
+       ↓  built by npm run build:translations
+i18n JSON locales      (frontend/packages/ui/src/i18n/locales/{locale}.json)
+       ↓  bundled into the iOS/macOS app at build time
+LocalizationManager    (apple/.../Core/I18n/LocalizationManager.swift)
+       ↓  type-safe accessors
+AppStrings             (apple/.../Core/I18n/AppStrings.swift)
+       ↓
+Swift UI
+```
+
+### Rules
+1. **NEVER write `Text("Some English text")` in a Swift view.** Always `Text(AppStrings.myKey)`.
+2. **NEVER call `LocalizationManager.shared.text("key")` directly from a view.** Add a
+   typed accessor to `AppStrings` first, then use that.
+3. **Every new string displayed in the UI needs a matching key in the YML source files**
+   (under `frontend/packages/ui/src/i18n/sources/`) AND a typed accessor in `AppStrings.swift`.
+4. If the key already exists in the JSON (check `en.json`), add only the `AppStrings` accessor.
+5. If the key does NOT exist, add it to the appropriate YML source file FIRST, run
+   `cd frontend/packages/ui && npm run build:translations`, then add the accessor.
+6. Replacements (e.g. `{count}`, `{time}`) use `LocalizationManager.shared.text(key, replacements: [...])`
+   wrapped in a typed `AppStrings` helper function.
+
+### Quick reference — keys for chat banner UI (all exist in en.json)
+| Displayed text | YML key | AppStrings accessor to add |
+|---|---|---|
+| "Creating new chat ..." | `chat.creating_new_chat` | `AppStrings.creatingNewChat` |
+| "Just now" | `chat.header.just_now` | `AppStrings.chatHeaderJustNow` |
+| "{n} min ago" | `chat.header.minutes_ago` | `AppStrings.chatHeaderMinutesAgo(count:)` |
+| "Started today, HH:MM" | `chat.header.started_today` | `AppStrings.chatHeaderStartedToday(time:)` |
+| "Started yesterday, HH:MM" | `chat.header.started_yesterday` | `AppStrings.chatHeaderStartedYesterday(time:)` |
+| "Incognito Mode" | `settings.incognito_mode_active` | `AppStrings.incognitoModeActive` |
+| Demo chat: "OpenMates \| For everyone" | `demo_chats.for_everyone.title` | `AppStrings.demoForEveryoneTitle` |
+| Demo chat: description | `demo_chats.for_everyone.description` | `AppStrings.demoForEveryoneDescription` |
+| Demo chat: "OpenMates \| For developers" | `demo_chats.for_developers.title` | `AppStrings.demoForDevelopersTitle` |
+| Demo chat: description | `demo_chats.for_developers.description` | `AppStrings.demoForDevelopersDescription` |
+
+---
+
 ## Mandatory: Web-Source Comment Block
 
 Every `.swift` file under `apple/OpenMates/Sources/` with visual output MUST

--- a/apple/OpenMates/Sources/App/MainAppView.swift
+++ b/apple/OpenMates/Sources/App/MainAppView.swift
@@ -3,6 +3,16 @@
 // Sidebar shows chat list; detail shows active chat or empty state.
 // Manages WebSocket connection and phased sync lifecycle.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/apps/web_app/src/routes/+page.svelte  (top-level layout)
+//          frontend/packages/ui/src/components/ChatHistory.svelte (sidebar)
+//          frontend/packages/ui/src/components/Header.svelte (top nav)
+// Default: Opens demo-for-everyone chat on cold-boot for unauthenticated users,
+//          matching +page.svelte logic (activeChatStore.setActiveChat('demo-for-everyone'))
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift,
+//          TypographyTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 import WidgetKit
 import CoreSpotlight
@@ -64,6 +74,13 @@ struct MainAppView: View {
         } detail: {
             if isAuthenticated, let chatId = selectedChatId {
                 ChatView(chatId: chatId)
+            } else if !isAuthenticated, let chatId = selectedChatId {
+                // Unauthenticated: show demo chat with its gradient banner
+                ChatView(
+                    chatId: chatId,
+                    bannerState: demoBannerState(for: chatId),
+                    bannerCreatedAt: nil
+                )
             } else if !isAuthenticated {
                 WelcomeView(onLogin: { showAuthSheet = true })
             } else {
@@ -395,29 +412,47 @@ struct MainAppView: View {
 
     // MARK: - Demo chats for unauthenticated users
 
-    /// Populates the sidebar with static demo chats so unauthenticated users
-    /// see the same welcoming experience as the web app's landing page.
+    /// Populates the sidebar with demo chats matching the web app's landing page.
+    /// Opens demo-for-everyone by default — same as +page.svelte cold-boot behaviour.
     private func loadDemoChats() {
         let now = ISO8601DateFormatter().string(from: Date())
+        // Titles via AppStrings → LocalizationManager → i18n JSON (never hardcoded English)
         let demoChats: [Chat] = [
-            Chat(id: "demo-1", title: "Welcome to OpenMates", lastMessageAt: now,
-                 createdAt: now, updatedAt: now, isArchived: false, isPinned: true,
+            // demo_chats.for_everyone.title
+            Chat(id: "demo-for-everyone", title: AppStrings.demoForEveryoneTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: true,
                  appId: "ai", encryptedTitle: nil, encryptedChatKey: nil),
-            Chat(id: "demo-2", title: "Plan a trip to Japan", lastMessageAt: now,
-                 createdAt: now, updatedAt: now, isArchived: false, isPinned: false,
-                 appId: "travel", encryptedTitle: nil, encryptedChatKey: nil),
-            Chat(id: "demo-3", title: "Healthy meal ideas", lastMessageAt: now,
-                 createdAt: now, updatedAt: now, isArchived: false, isPinned: false,
-                 appId: "nutrition", encryptedTitle: nil, encryptedChatKey: nil),
-            Chat(id: "demo-4", title: "Today's top news", lastMessageAt: now,
-                 createdAt: now, updatedAt: now, isArchived: false, isPinned: false,
-                 appId: "news", encryptedTitle: nil, encryptedChatKey: nil),
-            Chat(id: "demo-5", title: "Weekend events nearby", lastMessageAt: now,
-                 createdAt: now, updatedAt: now, isArchived: false, isPinned: false,
-                 appId: "events", encryptedTitle: nil, encryptedChatKey: nil),
+            // demo_chats.for_developers.title
+            Chat(id: "demo-for-developers", title: AppStrings.demoForDevelopersTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "code", encryptedTitle: nil, encryptedChatKey: nil),
         ]
         chatStore.upsertChats(demoChats)
-        selectedChatId = "demo-1"
+        // Open the for-everyone chat by default — matches web app's cold-boot behaviour
+        selectedChatId = "demo-for-everyone"
+    }
+
+    /// Returns the gradient banner state for a given demo chat ID.
+    /// Titles and descriptions via AppStrings → i18n JSON — never hardcoded English.
+    private func demoBannerState(for chatId: String) -> ChatBannerState? {
+        switch chatId {
+        case "demo-for-everyone":
+            return .loaded(
+                title: AppStrings.demoForEveryoneTitle,
+                appId: "ai",
+                summary: AppStrings.demoForEveryoneDescription
+            )
+        case "demo-for-developers":
+            return .loaded(
+                title: AppStrings.demoForDevelopersTitle,
+                appId: "code",
+                summary: AppStrings.demoForDevelopersDescription
+            )
+        default:
+            return nil
+        }
     }
 
     // MARK: - Data loading
@@ -650,6 +685,7 @@ struct WelcomeView: View {
                 .resizable()
                 .frame(width: 72, height: 72)
 
+            // Brand name — intentionally not translated (proper noun, same in all locales)
             Text("OpenMates")
                 .font(.omH1)
                 .fontWeight(.bold)
@@ -744,21 +780,38 @@ struct NewChatView: View {
                 }
                 .padding(.horizontal)
 
-                // Message input
+                // Message input — pill style matching ChatView.inputBar and fields.css
                 HStack(alignment: .bottom, spacing: .spacing3) {
                     TextField(AppStrings.startTyping, text: $messageText, axis: .vertical)
                         .textFieldStyle(.plain)
                         .font(.omP)
                         .lineLimit(1...4)
-                        .padding(.spacing4)
-                        .background(Color.grey10)
-                        .clipShape(RoundedRectangle(cornerRadius: .radius5))
+                        .padding(.horizontal, .spacing8)
+                        .padding(.vertical, .spacing6)
+                        .background(Color.grey0)
+                        .clipShape(RoundedRectangle(cornerRadius: .radiusFull))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: .radiusFull)
+                                .stroke(isFocused ? Color.buttonPrimary : Color.grey30, lineWidth: 2)
+                        )
+                        .shadow(
+                            color: isFocused ? Color.buttonPrimary.opacity(0.22) : .clear,
+                            radius: 3, x: 0, y: 0
+                        )
+                        .shadow(
+                            color: isFocused ? .black.opacity(0.08) : .black.opacity(0.05),
+                            radius: isFocused ? 12 : 2, x: 0, y: 4
+                        )
+                        .tint(Color.buttonPrimary)
                         .focused($isFocused)
 
-                    Button { createChat() } label: {
-                        Image(systemName: "arrow.up.circle.fill")
-                            .font(.system(size: 32))
-                            .foregroundStyle(messageText.isEmpty ? Color.fontTertiary : Color.buttonPrimary)
+                    Button(action: createChat) {
+                        Image(systemName: "arrow.up")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(messageText.isEmpty ? Color.fontTertiary : Color.fontButton)
+                            .frame(width: 32, height: 32)
+                            .background(messageText.isEmpty ? Color.grey20 : Color.buttonPrimary)
+                            .clipShape(Circle())
                     }
                     .disabled(messageText.isEmpty)
                 }

--- a/apple/OpenMates/Sources/App/MainAppView.swift
+++ b/apple/OpenMates/Sources/App/MainAppView.swift
@@ -310,6 +310,8 @@ struct MainAppView: View {
         }
         .listStyle(.plain)
         .listRowSeparator(.hidden)
+        .scrollContentBackground(.hidden)
+        .background(Color.grey0)
         .searchable(text: $searchText, prompt: AppStrings.search)
         .navigationTitle(AppStrings.chats)
         #if os(iOS)
@@ -412,44 +414,122 @@ struct MainAppView: View {
 
     // MARK: - Demo chats for unauthenticated users
 
-    /// Populates the sidebar with demo chats matching the web app's landing page.
+    /// Populates the sidebar with all public chats matching the web app's cold-boot landing page.
     /// Opens demo-for-everyone by default — same as +page.svelte cold-boot behaviour.
+    /// Mirrors: INTRO_CHATS + LEGAL_CHATS + announcements + example chats from demo_chats/index.ts
     private func loadDemoChats() {
         let now = ISO8601DateFormatter().string(from: Date())
-        // Titles via AppStrings → LocalizationManager → i18n JSON (never hardcoded English)
+        // All strings via AppStrings → LocalizationManager → i18n JSON (never hardcoded English)
         let demoChats: [Chat] = [
-            // demo_chats.for_everyone.title
+            // INTRO_CHATS (featured: true, pinned in sidebar)
             Chat(id: "demo-for-everyone", title: AppStrings.demoForEveryoneTitle,
                  lastMessageAt: now, createdAt: now, updatedAt: now,
                  isArchived: false, isPinned: true,
                  appId: "ai", encryptedTitle: nil, encryptedChatKey: nil),
-            // demo_chats.for_developers.title
             Chat(id: "demo-for-developers", title: AppStrings.demoForDevelopersTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: true,
+                 appId: "code", encryptedTitle: nil, encryptedChatKey: nil),
+            Chat(id: "demo-who-develops-openmates", title: AppStrings.demoWhoDevTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: true,
+                 appId: "ai", encryptedTitle: nil, encryptedChatKey: nil),
+            // Announcements newsletter chat
+            Chat(id: "announcements-introducing-openmates-v09", title: AppStrings.demoAnnouncementsV09Title,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "ai", encryptedTitle: nil, encryptedChatKey: nil),
+            // Legal chats (accessible via sidebar + settings)
+            Chat(id: "legal-privacy", title: AppStrings.legalPrivacyTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "ai", encryptedTitle: nil, encryptedChatKey: nil),
+            Chat(id: "legal-terms", title: AppStrings.legalTermsTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "ai", encryptedTitle: nil, encryptedChatKey: nil),
+            Chat(id: "legal-imprint", title: AppStrings.legalImprintTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "ai", encryptedTitle: nil, encryptedChatKey: nil),
+            // Example chats — real conversations (exampleChatStore.ts)
+            Chat(id: "example-gigantic-airplanes", title: AppStrings.exampleGiganticAirplanesTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "ai", encryptedTitle: nil, encryptedChatKey: nil),
+            Chat(id: "example-artemis-ii-mission", title: AppStrings.exampleArtemisMissionTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "ai", encryptedTitle: nil, encryptedChatKey: nil),
+            Chat(id: "example-beautiful-single-page-html", title: AppStrings.exampleBeautifulHtmlTitle,
                  lastMessageAt: now, createdAt: now, updatedAt: now,
                  isArchived: false, isPinned: false,
                  appId: "code", encryptedTitle: nil, encryptedChatKey: nil),
+            Chat(id: "example-eu-chat-control-law", title: AppStrings.exampleEuChatControlTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "legal", encryptedTitle: nil, encryptedChatKey: nil),
+            Chat(id: "example-flights-berlin-bangkok", title: AppStrings.exampleFlightsBerlinBangkokTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "travel", encryptedTitle: nil, encryptedChatKey: nil),
+            Chat(id: "example-creativity-drawing-meetups-berlin", title: AppStrings.exampleCreativityDrawingTitle,
+                 lastMessageAt: now, createdAt: now, updatedAt: now,
+                 isArchived: false, isPinned: false,
+                 appId: "events", encryptedTitle: nil, encryptedChatKey: nil),
         ]
         chatStore.upsertChats(demoChats)
         // Open the for-everyone chat by default — matches web app's cold-boot behaviour
         selectedChatId = "demo-for-everyone"
     }
 
-    /// Returns the gradient banner state for a given demo chat ID.
-    /// Titles and descriptions via AppStrings → i18n JSON — never hardcoded English.
+    /// Returns the gradient banner state for a given demo/legal/example chat ID.
+    /// All strings via AppStrings → i18n JSON — never hardcoded English.
     private func demoBannerState(for chatId: String) -> ChatBannerState? {
         switch chatId {
+        // INTRO_CHATS
         case "demo-for-everyone":
-            return .loaded(
-                title: AppStrings.demoForEveryoneTitle,
-                appId: "ai",
-                summary: AppStrings.demoForEveryoneDescription
-            )
+            return .loaded(title: AppStrings.demoForEveryoneTitle, appId: "ai",
+                           summary: AppStrings.demoForEveryoneDescription)
         case "demo-for-developers":
-            return .loaded(
-                title: AppStrings.demoForDevelopersTitle,
-                appId: "code",
-                summary: AppStrings.demoForDevelopersDescription
-            )
+            return .loaded(title: AppStrings.demoForDevelopersTitle, appId: "code",
+                           summary: AppStrings.demoForDevelopersDescription)
+        case "demo-who-develops-openmates":
+            return .loaded(title: AppStrings.demoWhoDevTitle, appId: "ai",
+                           summary: AppStrings.demoWhoDevDescription)
+        // Announcements
+        case "announcements-introducing-openmates-v09":
+            return .loaded(title: AppStrings.demoAnnouncementsV09Title, appId: "ai",
+                           summary: AppStrings.demoAnnouncementsV09Description)
+        // Legal chats
+        case "legal-privacy":
+            return .loaded(title: AppStrings.legalPrivacyTitle, appId: "ai",
+                           summary: AppStrings.legalPrivacyDescription)
+        case "legal-terms":
+            return .loaded(title: AppStrings.legalTermsTitle, appId: "ai",
+                           summary: AppStrings.legalTermsDescription)
+        case "legal-imprint":
+            return .loaded(title: AppStrings.legalImprintTitle, appId: "ai",
+                           summary: AppStrings.legalImprintDescription)
+        // Example chats
+        case "example-gigantic-airplanes":
+            return .loaded(title: AppStrings.exampleGiganticAirplanesTitle, appId: "ai",
+                           summary: AppStrings.exampleGiganticAirplanesSummary)
+        case "example-artemis-ii-mission":
+            return .loaded(title: AppStrings.exampleArtemisMissionTitle, appId: "ai",
+                           summary: AppStrings.exampleArtemisMissionSummary)
+        case "example-beautiful-single-page-html":
+            return .loaded(title: AppStrings.exampleBeautifulHtmlTitle, appId: "code",
+                           summary: AppStrings.exampleBeautifulHtmlSummary)
+        case "example-eu-chat-control-law":
+            return .loaded(title: AppStrings.exampleEuChatControlTitle, appId: "legal",
+                           summary: AppStrings.exampleEuChatControlSummary)
+        case "example-flights-berlin-bangkok":
+            return .loaded(title: AppStrings.exampleFlightsBerlinBangkokTitle, appId: "travel",
+                           summary: AppStrings.exampleFlightsBerlinBangkokSummary)
+        case "example-creativity-drawing-meetups-berlin":
+            return .loaded(title: AppStrings.exampleCreativityDrawingTitle, appId: "events",
+                           summary: AppStrings.exampleCreativityDrawingSummary)
         default:
             return nil
         }

--- a/apple/OpenMates/Sources/Core/I18n/AppStrings.swift
+++ b/apple/OpenMates/Sources/Core/I18n/AppStrings.swift
@@ -232,6 +232,30 @@ enum AppStrings {
     static var rename: String { L("common.rename") }
     static var stop: String { L("common.stop") }
 
+    // MARK: - Chat banner (ChatHeader.svelte)
+    static var creatingNewChat: String { L("chat.creating_new_chat") }
+    static var chatHeaderJustNow: String { L("chat.header.just_now") }
+    static var incognitoModeActive: String { L("settings.incognito_mode_active") }
+
+    static func chatHeaderMinutesAgo(count: Int) -> String {
+        LocalizationManager.shared.text("chat.header.minutes_ago", replacements: ["count": "\(count)"])
+    }
+    static func chatHeaderStartedToday(time: String) -> String {
+        LocalizationManager.shared.text("chat.header.started_today", replacements: ["time": time])
+    }
+    static func chatHeaderStartedYesterday(time: String) -> String {
+        LocalizationManager.shared.text("chat.header.started_yesterday", replacements: ["time": time])
+    }
+    static func chatHeaderStartedOn(date: String, time: String) -> String {
+        "\(date), \(time)"
+    }
+
+    // MARK: - Demo chats
+    static var demoForEveryoneTitle: String { L("demo_chats.for_everyone.title") }
+    static var demoForEveryoneDescription: String { L("demo_chats.for_everyone.description") }
+    static var demoForDevelopersTitle: String { L("demo_chats.for_developers.title") }
+    static var demoForDevelopersDescription: String { L("demo_chats.for_developers.description") }
+
     // MARK: - Credits
     static func creditsAmount(_ amount: String) -> String {
         LocalizationManager.shared.text("settings.credits_amount", replacements: ["credits_amount": amount])

--- a/apple/OpenMates/Sources/Core/I18n/AppStrings.swift
+++ b/apple/OpenMates/Sources/Core/I18n/AppStrings.swift
@@ -203,6 +203,15 @@ enum AppStrings {
     static var twoFactorRequired: String { L("auth.two_factor_required") }
     static var invalidCredentials: String { L("auth.invalid_credentials") }
 
+    // MARK: - Enter message / action buttons (ActionButtons.svelte)
+    static var attachFiles: String { L("enter_message.attachments.attach_files") }
+    static var shareLocation: String { L("enter_message.attachments.share_location") }
+    static var sketchAction: String { L("enter_message.attachments.sketch") }
+    static var takePhoto: String { L("enter_message.attachments.take_photo") }
+    static var recordAudio: String { L("enter_message.attachments.record_audio") }
+    static var pressAndHoldToRecord: String { L("enter_message.record_audio.press_and_hold_reminder") }
+    static var enterMessagePlaceholder: String { L("enter_message.placeholder.touch") }
+
     // MARK: - Embeds
     static var voiceRecording: String { L("embed.voice_recording") }
     static var transcription: String { L("embed.transcription") }
@@ -250,11 +259,37 @@ enum AppStrings {
         "\(date), \(time)"
     }
 
-    // MARK: - Demo chats
+    // MARK: - Demo chats — intro
     static var demoForEveryoneTitle: String { L("demo_chats.for_everyone.title") }
     static var demoForEveryoneDescription: String { L("demo_chats.for_everyone.description") }
     static var demoForDevelopersTitle: String { L("demo_chats.for_developers.title") }
     static var demoForDevelopersDescription: String { L("demo_chats.for_developers.description") }
+    static var demoWhoDevTitle: String { L("demo_chats.who_develops_openmates.title") }
+    static var demoWhoDevDescription: String { L("demo_chats.who_develops_openmates.description") }
+    static var demoAnnouncementsV09Title: String { L("demo_chats.announcements_introducing_openmates_v09.title") }
+    static var demoAnnouncementsV09Description: String { L("demo_chats.announcements_introducing_openmates_v09.description") }
+
+    // MARK: - Legal chats
+    static var legalPrivacyTitle: String { L("legal.privacy.title") }
+    static var legalPrivacyDescription: String { L("metadata.legal_privacy.description") }
+    static var legalTermsTitle: String { L("legal.terms.title") }
+    static var legalTermsDescription: String { L("metadata.legal_terms.description") }
+    static var legalImprintTitle: String { L("legal.imprint.title") }
+    static var legalImprintDescription: String { L("metadata.legal_imprint.description") }
+
+    // MARK: - Example chats
+    static var exampleGiganticAirplanesTitle: String { L("example_chats.gigantic_airplanes.title") }
+    static var exampleGiganticAirplanesSummary: String { L("example_chats.gigantic_airplanes.summary") }
+    static var exampleArtemisMissionTitle: String { L("example_chats.artemis_ii_mission.title") }
+    static var exampleArtemisMissionSummary: String { L("example_chats.artemis_ii_mission.summary") }
+    static var exampleBeautifulHtmlTitle: String { L("example_chats.beautiful_single_page_html.title") }
+    static var exampleBeautifulHtmlSummary: String { L("example_chats.beautiful_single_page_html.summary") }
+    static var exampleEuChatControlTitle: String { L("example_chats.eu_chat_control_law.title") }
+    static var exampleEuChatControlSummary: String { L("example_chats.eu_chat_control_law.summary") }
+    static var exampleFlightsBerlinBangkokTitle: String { L("example_chats.flights_berlin_bangkok.title") }
+    static var exampleFlightsBerlinBangkokSummary: String { L("example_chats.flights_berlin_bangkok.summary") }
+    static var exampleCreativityDrawingTitle: String { L("example_chats.creativity_drawing_meetups_berlin.title") }
+    static var exampleCreativityDrawingSummary: String { L("example_chats.creativity_drawing_meetups_berlin.summary") }
 
     // MARK: - Credits
     static func creditsAmount(_ amount: String) -> String {

--- a/apple/OpenMates/Sources/Features/Auth/Views/AuthFlowView.swift
+++ b/apple/OpenMates/Sources/Features/Auth/Views/AuthFlowView.swift
@@ -3,6 +3,13 @@
 // password entry, passkey, recovery key, and backup code screens.
 // VoiceOver: screen change announcements on step transitions, combined header group.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/Login.svelte
+//          frontend/packages/ui/src/components/LoginMethodSelector.svelte
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift,
+//          TypographyTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct AuthFlowView: View {

--- a/apple/OpenMates/Sources/Features/Chat/Views/ChatBannerView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/ChatBannerView.swift
@@ -1,0 +1,262 @@
+// Gradient banner displayed at the top of the chat message list.
+// Shown for demo/example chats and new chats while the title is generating.
+
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/ChatHeader.svelte
+// CSS:     frontend/packages/ui/src/components/ChatHeader.svelte <style>
+//          .chat-header { height:50vh; min-height:240px; border-radius:14px }
+//          .chat-header-content (centered icon + title + summary)
+//          .deco-icon-left / .deco-icon-right { opacity:0.4; width:126px }
+// i18n:    frontend/packages/ui/src/i18n/sources/chat/main.yml
+//          Keys: chat.creating_new_chat, chat.header.just_now,
+//                chat.header.minutes_ago, chat.header.started_today,
+//                chat.header.started_yesterday
+//          frontend/packages/ui/src/i18n/sources/settings/main.yml
+//          Key: settings.incognito_mode_active
+// Tokens:  GradientTokens.generated.swift, ColorTokens.generated.swift,
+//          SpacingTokens.generated.swift, TypographyTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
+import SwiftUI
+
+/// Matches the three visual states of ChatHeader.svelte:
+/// - loading:  primary blue gradient + "Creating new chat …" shimmer
+/// - loaded:   category gradient + icon + title + optional summary
+/// - incognito: fixed dark gradient + incognito label
+enum ChatBannerState {
+    case loading
+    case loaded(title: String, appId: String, summary: String?)
+    case incognito
+}
+
+/// Full-width gradient banner positioned at the top of the chat scroll view.
+/// Heights mirror the web CSS: 240pt minimum (iPad/Mac), 190pt minimum (iPhone compact).
+struct ChatBannerView: View {
+    let state: ChatBannerState
+    var createdAt: Date? = nil
+
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @State private var shimmerOffset: CGFloat = -200
+
+    private var minHeight: CGFloat { sizeClass == .compact ? 190 : 240 }
+
+    var body: some View {
+        ZStack {
+            gradientBackground
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+
+            // Decorative large icons at left/right edges — opacity 0.4, matching web deco-icon-left/right
+            if case .loaded(_, let appId, _) = state {
+                HStack {
+                    AppIconView(appId: appId, size: 100)
+                        .opacity(0.25)
+                        .offset(x: -28)
+                    Spacer()
+                    AppIconView(appId: appId, size: 100)
+                        .opacity(0.25)
+                        .offset(x: 28)
+                }
+                .clipped()
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+
+            centerContent
+        }
+        .frame(maxWidth: .infinity)
+        .frame(minHeight: minHeight)
+    }
+
+    // MARK: - Gradient background
+
+    @ViewBuilder
+    private var gradientBackground: some View {
+        switch state {
+        case .incognito:
+            LinearGradient(
+                colors: [Color(hex: 0x1A1A2E), Color(hex: 0x2D2D44), Color(hex: 0x1E1E35)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        case .loading:
+            LinearGradient.primary
+        case .loaded(_, let appId, _):
+            ChatHeaderView.appGradientForBanner(appId: appId)
+        }
+    }
+
+    // MARK: - Center content
+
+    @ViewBuilder
+    private var centerContent: some View {
+        switch state {
+        case .loading:
+            VStack(spacing: .spacing4) {
+                Circle()
+                    .fill(Color.white.opacity(0.35))
+                    .frame(width: 38, height: 38)
+                    .overlay(shimmerOverlay)
+
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.white.opacity(0.35))
+                    .frame(width: 180, height: 20)
+                    .overlay(shimmerOverlay)
+
+                // i18n: chat.creating_new_chat
+                Text(AppStrings.creatingNewChat)
+                    .font(.omP).fontWeight(.semibold)
+                    .foregroundStyle(.white.opacity(0.0))
+            }
+            .onAppear { animateShimmer() }
+
+        case .incognito:
+            VStack(spacing: .spacing4) {
+                Image(systemName: "person.fill.questionmark")
+                    .font(.system(size: 38))
+                    .foregroundStyle(.white)
+                // i18n: settings.incognito_mode_active
+                Text(AppStrings.incognitoModeActive)
+                    .font(.omH4).fontWeight(.bold)
+                    .foregroundStyle(.white)
+            }
+
+        case .loaded(let title, let appId, let summary):
+            VStack(spacing: .spacing3) {
+                AppIconView(appId: appId, size: 38)
+                    .colorMultiply(.white)
+
+                Text(title)
+                    .font(.omH4).fontWeight(.bold)
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, .spacing10)
+
+                if let summary, !summary.isEmpty {
+                    Text(summary)
+                        .font(.omSmall)
+                        .foregroundStyle(.white.opacity(0.85))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, .spacing10)
+                        .lineLimit(3)
+                }
+
+                if let createdAt {
+                    // i18n: chat.header.just_now / minutes_ago / started_today / started_yesterday
+                    Text(relativeTime(from: createdAt))
+                        .font(.omXs)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+            }
+            .padding(.vertical, .spacing8)
+        }
+    }
+
+    // MARK: - Shimmer
+
+    private var shimmerOverlay: some View {
+        GeometryReader { geo in
+            Rectangle()
+                .fill(
+                    LinearGradient(
+                        colors: [.clear, .white.opacity(0.5), .clear],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .offset(x: shimmerOffset)
+                .frame(width: geo.size.width * 2)
+                .clipped()
+        }
+        .clipped()
+    }
+
+    private func animateShimmer() {
+        withAnimation(.linear(duration: 1.4).repeatForever(autoreverses: false)) {
+            shimmerOffset = 400
+        }
+    }
+
+    // MARK: - Time formatting (i18n via AppStrings)
+
+    private func relativeTime(from date: Date) -> String {
+        let diff = Date().timeIntervalSince(date)
+        let minutes = Int(diff / 60)
+        let fmt = DateFormatter()
+        fmt.dateFormat = "HH:mm"
+        let timeStr = fmt.string(from: date)
+
+        if minutes < 1 { return AppStrings.chatHeaderJustNow }
+        if minutes <= 10 { return AppStrings.chatHeaderMinutesAgo(count: minutes) }
+
+        let calendar = Calendar.current
+        if calendar.isDateInToday(date) {
+            return AppStrings.chatHeaderStartedToday(time: timeStr)
+        }
+        if calendar.isDateInYesterday(date) {
+            return AppStrings.chatHeaderStartedYesterday(time: timeStr)
+        }
+        let dateFmt = DateFormatter()
+        dateFmt.dateFormat = "yyyy/MM/dd"
+        return AppStrings.chatHeaderStartedOn(date: dateFmt.string(from: date), time: timeStr)
+    }
+}
+
+// MARK: - Gradient helper (kept in ChatHeaderView extension for callers that use it directly)
+
+extension ChatHeaderView {
+    static func appGradientForBanner(appId: String) -> LinearGradient {
+        switch appId {
+        case "ai": return .appAi
+        case "web": return .appWeb
+        case "code": return .appCode
+        case "travel": return .appTravel
+        case "news": return .appNews
+        case "mail": return .appMail
+        case "maps": return .appMaps
+        case "shopping": return .appShopping
+        case "events": return .appEvents
+        case "videos": return .appVideos
+        case "photos": return .appPhotos
+        case "images": return .appImages
+        case "nutrition": return .appNutrition
+        case "health": return .appHealth
+        case "home": return .appHome
+        case "finance": return .appFinance
+        case "fitness": return .appFitness
+        case "legal": return .appLegal
+        case "weather": return .appWeather
+        case "jobs": return .appJobs
+        case "files": return .appFiles
+        case "docs": return .appDocs
+        case "slides": return .appSlides
+        case "sheets": return .appSheets
+        case "notes": return .appNotes
+        case "whiteboards": return .appWhiteboards
+        case "language": return .appLanguage
+        case "diagrams": return .appDiagrams
+        case "calendar": return .appCalendar
+        case "reminder": return .appReminder
+        case "business": return .appBusiness
+        case "music": return .appMusic
+        case "audio": return .appAudio
+        case "design": return .appDesign
+        case "pdf": return .appPdf
+        case "publishing": return .appPublishing
+        case "socialmedia": return .appSocialmedia
+        case "projectmanagement": return .appProjectmanagement
+        case "messages": return .appMessages
+        case "books": return .appBooks
+        case "plants": return .appPlants
+        case "beauty": return .appBeauty
+        case "hosting": return .appHosting
+        case "fashion": return .appFashion
+        case "tv": return .appTv
+        case "movies": return .appMovies
+        case "secrets": return .appSecrets
+        case "study": return .appStudy
+        case "contacts": return .appContacts
+        case "calculator": return .appCalculator
+        case "games": return .appGames
+        default: return .primary
+        }
+    }
+}

--- a/apple/OpenMates/Sources/Features/Chat/Views/ChatContextMenu.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/ChatContextMenu.swift
@@ -1,6 +1,11 @@
 // Chat context menu — long-press/right-click actions on chat list items.
 // Mirrors ChatContextMenu.svelte: pin, hide, share, archive, delete, rename.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/chats/ChatContextMenu.svelte
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct ChatContextMenuActions: View {

--- a/apple/OpenMates/Sources/Features/Chat/Views/ChatHeaderView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/ChatHeaderView.swift
@@ -1,6 +1,15 @@
-// Chat header — gradient banner at the top of a chat with title, category, and app icon.
-// Mirrors the web app's ChatHeader.svelte with animated gradient background
-// based on the chat's app category, shimmer effect during loading.
+// Chat header — compact inline toolbar title with app icon and chat title.
+// Replaces the old 80pt hardcoded gradient banner.
+
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/ChatHeader.svelte
+//          Inline navigation-bar variant (title + small app icon in HStack).
+//          The full gradient banner for new chats is implemented separately
+//          in NewChatBannerView.swift.
+// Tokens:  GradientTokens.generated.swift  (LinearGradient.appAi, .appWeb, etc.)
+//          ColorTokens.generated.swift
+//          TypographyTokens.generated.swift (Font.omSmall)
+// ────────────────────────────────────────────────────────────────────
 
 import SwiftUI
 
@@ -12,103 +21,26 @@ struct ChatHeaderView: View {
     private var title: String { chat?.displayTitle ?? "" }
 
     var body: some View {
-        ZStack(alignment: .bottomLeading) {
-            gradientBackground
-            if isLoading {
-                shimmerOverlay
-            }
-            headerContent
-        }
-        .frame(height: 80)
-        .clipShape(RoundedRectangle(cornerRadius: 0))
-    }
-
-    private var gradientBackground: some View {
-        Group {
-            if let appId {
-                LinearGradient(
-                    colors: gradientColors(for: appId),
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            } else {
-                LinearGradient.primary
-            }
-        }
-        .opacity(0.15)
-    }
-
-    private var headerContent: some View {
         HStack(spacing: .spacing3) {
             if let appId {
-                AppIconView(appId: appId, size: 28)
+                AppIconView(appId: appId, size: 20)
             }
 
-            VStack(alignment: .leading, spacing: .spacing1) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text(title)
                     .font(.omSmall).fontWeight(.semibold)
                     .foregroundStyle(Color.fontPrimary)
                     .lineLimit(1)
-
-                if let appId {
-                    Text(appId.capitalized)
-                        .font(.omTiny)
-                        .foregroundStyle(Color.fontTertiary)
-                }
             }
 
             Spacer()
-        }
-        .padding(.horizontal, .spacing4)
-        .padding(.bottom, .spacing3)
-    }
 
-    private var shimmerOverlay: some View {
-        ShimmerView()
-            .opacity(0.3)
-    }
-
-    private func gradientColors(for appId: String) -> [Color] {
-        switch appId {
-        case "ai": return [.blue, .purple]
-        case "web": return [.cyan, .blue]
-        case "code": return [.green, .teal]
-        case "travel": return [.orange, .pink]
-        case "news": return [.red, .orange]
-        case "mail": return [.blue, .cyan]
-        case "maps": return [.green, .blue]
-        case "shopping": return [.pink, .purple]
-        case "events": return [.purple, .pink]
-        case "videos": return [.red, .pink]
-        case "photos", "images": return [.indigo, .purple]
-        case "nutrition": return [.green, .yellow]
-        case "health": return [.red, .pink]
-        case "home": return [.orange, .brown]
-        default: return [.blue, .purple]
-        }
-    }
-}
-
-// MARK: - Shimmer effect
-
-struct ShimmerView: View {
-    @State private var offset: CGFloat = -1
-
-    var body: some View {
-        GeometryReader { geo in
-            LinearGradient(
-                colors: [.clear, .white.opacity(0.3), .clear],
-                startPoint: .leading,
-                endPoint: .trailing
-            )
-            .frame(width: geo.size.width * 0.6)
-            .offset(x: offset * geo.size.width)
-            .onAppear {
-                withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
-                    offset = 1.5
-                }
+            if isLoading {
+                ProgressView()
+                    .scaleEffect(0.6)
             }
         }
-        .clipped()
+        .padding(.horizontal, .spacing4)
     }
+
 }

--- a/apple/OpenMates/Sources/Features/Chat/Views/ChatView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/ChatView.swift
@@ -3,10 +3,41 @@
 // inline embed previews, and fullscreen embed sheets. Advertises the current
 // chat for Handoff so users can continue on another Apple device.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// MessageBubble:
+//   Svelte:  frontend/packages/ui/src/components/ChatMessage.svelte
+//   CSS:     frontend/packages/ui/src/styles/chat.css
+//            .mate-message-content  { background:var(--color-grey-0); border-radius:13px;
+//              filter:drop-shadow(0 4px 4px rgba(0,0,0,.25)); padding:12px }
+//            .user-message-content  { background:var(--color-grey-blue); color:var(--color-grey-100) }
+//            .user-message-content::before / .mate-message-content::before  (SVG tail)
+//            speechbubble.svg       { viewBox: 0 0 7 11 → rendered 12×20pt }
+//
+// inputBar:
+//   Svelte:  frontend/packages/ui/src/components/enter_message/MessageInput.svelte
+//   CSS:     frontend/packages/ui/src/styles/fields.css
+//            border-radius:24px; border:2px solid var(--color-grey-0);
+//            :focus { border-color:var(--color-button-primary);
+//              box-shadow:0 0 0 3px rgba(255,85,59,.22), 0 4px 12px rgba(0,0,0,.08) }
+//
+// messageList / StreamingIndicator:
+//   Svelte:  frontend/packages/ui/src/components/ChatHistory.svelte
+//   CSS:     frontend/packages/ui/src/styles/chat.css
+//            .chat-history-content { max-width:1000px; margin:0 auto }
+//
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift,
+//          TypographyTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct ChatView: View {
     let chatId: String
+    /// Optional gradient banner state. Provide `.loaded` for demo/example chats;
+    /// omit (nil) for regular user chats where no banner should appear.
+    var bannerState: ChatBannerState? = nil
+    var bannerCreatedAt: Date? = nil
+
     @StateObject private var viewModel = ChatViewModel()
     @StateObject private var handoffManager = HandoffManager()
     @State private var messageText = ""
@@ -122,6 +153,14 @@ struct ChatView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: .spacing4) {
+                    // Gradient banner — shown for demo/example chats (ChatHeader.svelte equivalent)
+                    if let banner = bannerState {
+                        ChatBannerView(state: banner, createdAt: bannerCreatedAt)
+                            .padding(.horizontal, .spacing4)
+                            .padding(.top, .spacing4)
+                            .id("banner")
+                    }
+
                     // Load older messages button at the top
                     if viewModel.hasOlderMessages {
                         Button {
@@ -231,7 +270,7 @@ struct ChatView: View {
         }
         .padding(.horizontal, .spacing4)
         .padding(.vertical, .spacing2)
-        .background(Color.grey10)
+        .background(Color.grey0)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(AppStrings.aiResponding)
     }
@@ -264,7 +303,7 @@ struct ChatView: View {
                     .overlay(
                         RoundedRectangle(cornerRadius: .radiusFull)
                             .stroke(
-                                isInputFocused ? Color.buttonPrimary : Color.grey0,
+                                isInputFocused ? Color.buttonPrimary : Color.grey30,
                                 lineWidth: 2
                             )
                     )

--- a/apple/OpenMates/Sources/Features/Chat/Views/DailyInspirationView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/DailyInspirationView.swift
@@ -1,6 +1,15 @@
 // Daily inspiration banner — shows a rotating inspiration prompt.
 // Tapping creates a new chat with the inspiration as the first message.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/DailyInspirationBanner.svelte
+// CSS:     DailyInspirationBanner.svelte <style>
+//          Banner height: 240px desktop, 190px mobile (≤730px)
+//          Background: getCategoryGradientColors per inspiration category
+// i18n:    common.daily_inspiration (AppStrings.dailyInspiration)
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct DailyInspirationBanner: View {

--- a/apple/OpenMates/Sources/Features/Chat/Views/FollowUpSuggestions.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/FollowUpSuggestions.swift
@@ -1,6 +1,17 @@
 // Follow-up suggestion chips — AI-generated suggestions shown after responses.
 // Tapping a chip fills the message input with the suggestion text.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/FollowUpSuggestions.svelte
+// CSS:     frontend/packages/ui/src/styles/chat.css
+//          .follow-up-suggestions-wrapper (padding, alignment with assistant messages)
+// Note:    Web renders a full gradient banner card with animated orbs and
+//          pagination. The Swift version is simplified to horizontal pill chips
+//          appropriate for compact mobile layout.
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift,
+//          TypographyTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct FollowUpSuggestions: View {
@@ -17,8 +28,9 @@ struct FollowUpSuggestions: View {
                         } label: {
                             Text(suggestion)
                                 .font(.omSmall)
+                                .fontWeight(.medium)
                                 .foregroundStyle(Color.fontPrimary)
-                                .padding(.horizontal, .spacing4)
+                                .padding(.horizontal, .spacing6)
                                 .padding(.vertical, .spacing3)
                                 .background(Color.grey10)
                                 .clipShape(RoundedRectangle(cornerRadius: .radiusFull))

--- a/apple/OpenMates/Sources/Features/Chat/Views/ForkProgressBannerView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/ForkProgressBannerView.swift
@@ -2,6 +2,11 @@
 // Mirrors the web app's chats/ForkProgressBanner.svelte: progress indicator
 // displayed while the backend copies messages to the new forked chat.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/chats/ForkProgressBanner.svelte
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct ForkProgressBanner: View {

--- a/apple/OpenMates/Sources/Features/Chat/Views/InputActionButtons.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/InputActionButtons.swift
@@ -1,58 +1,69 @@
-// Input action buttons — row of quick-action buttons above the message input.
-// Mirrors the web app's enter_message/ActionButtons.svelte: camera, sketch,
-// maps, and file attachment shortcuts.
+// Input action buttons displayed inside the message field.
+// Mirrors ActionButtons.svelte: left side has files/maps/sketch, right side has camera/record.
+
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/enter_message/ActionButtons.svelte
+// CSS:     ActionButtons.svelte <style>
+//          .action-buttons { position:absolute; bottom:1rem; left:1rem; right:1rem;
+//                            display:flex; justify-content:space-between; height:40px }
+//          .left-buttons / .right-buttons { gap:1rem }
+// i18n:    enter_message.attachments.{attach_files,share_location,sketch,take_photo,record_audio}
+//          enter_message.record_audio.press_and_hold_reminder
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
 
 import SwiftUI
 
 struct InputActionButtons: View {
-    let onCamera: () -> Void
-    let onSketch: () -> Void
-    let onMaps: () -> Void
     let onAttach: () -> Void
-    @State private var isExpanded = false
+    let onMaps: () -> Void
+    let onSketch: () -> Void
+    let onCamera: () -> Void
+    let onRecord: () -> Void
+    /// Shows the "Press & hold to record" hint — set by parent after a short mic tap.
+    var showPressHoldHint: Bool = false
 
     var body: some View {
-        HStack(spacing: .spacing2) {
-            Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isExpanded.toggle()
-                }
-            } label: {
-                Image(systemName: isExpanded ? "xmark" : "plus")
-                    .font(.system(size: 18, weight: .medium))
-                    .foregroundStyle(Color.fontSecondary)
-                    .frame(width: 32, height: 32)
+        HStack {
+            // Left buttons: files, location, sketch
+            HStack(spacing: .spacing8) {
+                ActionIcon(systemName: "paperclip", label: AppStrings.attachFiles, action: onAttach)
+                ActionIcon(systemName: "location", label: AppStrings.shareLocation, action: onMaps)
+                ActionIcon(systemName: "pencil.tip", label: AppStrings.sketchAction, action: onSketch)
             }
-            .accessibilityLabel(isExpanded ? "Close actions" : "More actions")
 
-            if isExpanded {
-                Group {
-                    #if os(iOS)
-                    ActionButton(icon: "camera", label: "Camera", action: onCamera)
-                    ActionButton(icon: "paintbrush.pointed", label: "Sketch", action: onSketch)
-                    #endif
-                    ActionButton(icon: "map", label: "Location", action: onMaps)
-                    ActionButton(icon: "paperclip", label: "File", action: onAttach)
+            Spacer()
+
+            // Right buttons: [press-hold hint] camera, record
+            HStack(spacing: .spacing8) {
+                if showPressHoldHint {
+                    Text(AppStrings.pressAndHoldToRecord)
+                        .font(.omXs)
+                        .foregroundStyle(Color.fontTertiary)
+                        .transition(.opacity)
                 }
-                .transition(.scale.combined(with: .opacity))
+                #if os(iOS)
+                ActionIcon(systemName: "camera", label: AppStrings.takePhoto, action: onCamera)
+                #endif
+                ActionIcon(systemName: "mic", label: AppStrings.recordAudio, action: onRecord)
             }
         }
+        .frame(height: 40)
+        .animation(.easeInOut(duration: 0.2), value: showPressHoldHint)
     }
 }
 
-private struct ActionButton: View {
-    let icon: String
+private struct ActionIcon: View {
+    let systemName: String
     let label: String
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: icon)
-                .font(.system(size: 16))
+            Image(systemName: systemName)
+                .font(.system(size: 18))
                 .foregroundStyle(Color.fontSecondary)
                 .frame(width: 32, height: 32)
-                .background(Color.grey10)
-                .clipShape(Circle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(label)

--- a/apple/OpenMates/Sources/Features/Chat/Views/MentionDropdownView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/MentionDropdownView.swift
@@ -2,6 +2,11 @@
 // Mirrors the web app's enter_message/MentionDropdown.svelte: triggered when user
 // types @ in the message input, shows filterable list of mentionable items.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/enter_message/MentionDropdown.svelte
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct MentionDropdownView: View {

--- a/apple/OpenMates/Sources/Features/Chat/Views/MessageContextMenu.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/MessageContextMenu.swift
@@ -1,6 +1,11 @@
 // Message context menu — long-press/right-click actions on individual messages.
 // Mirrors MessageContextMenu.svelte: copy, edit, delete, fork.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/chats/MessageContextMenu.svelte
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct MessageContextMenu: View {

--- a/apple/OpenMates/Sources/Features/Chat/Views/NewChatSuggestionsView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/NewChatSuggestionsView.swift
@@ -2,6 +2,12 @@
 // Mirrors the web app's NewChatSuggestions.svelte + ChatSearchSuggestions.svelte.
 // Shows app-aware suggestions and search-based quick actions.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/NewChatSuggestions.svelte
+//          frontend/packages/ui/src/components/ChatSearchSuggestions.svelte
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct NewChatSuggestionsView: View {

--- a/apple/OpenMates/Sources/Features/Chat/Views/ProcessingDetailsView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/ProcessingDetailsView.swift
@@ -2,6 +2,11 @@
 // Mirrors the web app's ProcessingDetails.svelte: "Using apps", "Loaded preferences",
 // skill execution steps, and preprocessing progress.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/ProcessingDetails.svelte
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct ProcessingDetailsView: View {

--- a/apple/OpenMates/Sources/Features/Chat/Views/ThinkingSectionView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/ThinkingSectionView.swift
@@ -2,6 +2,11 @@
 // Mirrors the web app's ThinkingSection.svelte: collapsible section that shows
 // the AI's chain-of-thought when the model returns thinking blocks.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/ThinkingSection.svelte
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct ThinkingSectionView: View {

--- a/apple/OpenMates/Sources/Features/Chat/Views/VoiceRecordingView.swift
+++ b/apple/OpenMates/Sources/Features/Chat/Views/VoiceRecordingView.swift
@@ -1,6 +1,14 @@
 // Voice recording input — record audio messages directly in chat.
 // Mirrors RecordAudio.svelte: start/stop/cancel, duration timer, waveform.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/enter_message/RecordAudio.svelte
+// CSS:     RecordAudio.svelte <style>
+// i18n:    enter_message.record_audio.{slide_left_to_cancel,release_to_finish,
+//          press_and_hold_reminder,allow_microphone_access,microphone_blocked}
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 import AVFoundation
 

--- a/apple/OpenMates/Sources/Features/Embeds/Views/EmbedContentView.swift
+++ b/apple/OpenMates/Sources/Features/Embeds/Views/EmbedContentView.swift
@@ -2,6 +2,12 @@
 // Mirrors the EMBED_PREVIEW_COMPONENTS / EMBED_FULLSCREEN_COMPONENTS registry.
 // Supports preview (compact card) and fullscreen (full detail) modes.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/embeds/UnifiedEmbedPreview.svelte
+//          frontend/packages/ui/src/components/embeds/UnifiedEmbedFullscreen.svelte
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 enum EmbedDisplayMode {

--- a/apple/OpenMates/Sources/Features/PublicChats/Views/PublicChatListView.swift
+++ b/apple/OpenMates/Sources/Features/PublicChats/Views/PublicChatListView.swift
@@ -1,6 +1,12 @@
 // Public chat browser — shows intro, example, announcement, and tips chats.
 // Shown from the main app's "Explore" tab or from the sidebar.
 
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/apps/web_app/src/routes/+page.svelte (explore/public chats)
+//          frontend/packages/ui/src/components/ChatHistory.svelte (chat list)
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
+
 import SwiftUI
 
 struct PublicChatListView: View {

--- a/apple/OpenMates/Sources/Shared/Components/ChatListRow.swift
+++ b/apple/OpenMates/Sources/Shared/Components/ChatListRow.swift
@@ -1,5 +1,16 @@
 // Chat list row — single row in the chat sidebar.
-// Shows app gradient icon, title, relative timestamp, and pin indicator.
+
+// ─── Web source ─────────────────────────────────────────────────────
+// Svelte:  frontend/packages/ui/src/components/chats/Chat.svelte
+// CSS:     frontend/packages/ui/src/components/chats/Chat.svelte <style>
+//          .category-circle-wrapper { flex:0 0 28px; height:28px }
+//          .category-circle { width:28px; height:28px; border-radius:50%;
+//            box-shadow:0 2px 4px rgba(0,0,0,.1); border:2px solid var(--color-background) }
+//          .chat-title { font-size:var(--font-size-p); font-weight:500 }
+//          .chat-time  { font-size:14px; color:var(--color-font-tertiary) }
+// Tokens:  ColorTokens.generated.swift, SpacingTokens.generated.swift,
+//          TypographyTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
 
 import SwiftUI
 
@@ -9,17 +20,19 @@ struct ChatListRow: View {
     var body: some View {
         HStack(spacing: .spacing4) {
             if let appId = chat.appId {
-                AppIconView(appId: appId, size: 36)
+                AppIconView(appId: appId, size: 28)
+                    .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 2)
             } else {
                 Circle()
                     .fill(LinearGradient.primary)
-                    .frame(width: 36, height: 36)
+                    .frame(width: 28, height: 28)
                     .overlay {
                         Image.iconChat
                             .resizable()
-                            .frame(width: 18, height: 18)
+                            .frame(width: 16, height: 16)
                             .foregroundStyle(.white)
                     }
+                    .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 2)
             }
 
             VStack(alignment: .leading, spacing: .spacing1) {
@@ -40,11 +53,12 @@ struct ChatListRow: View {
 
             if chat.isPinned == true {
                 Image(systemName: SFSymbol.pin)
-                    .font(.caption)
+                    .font(.omTiny)
                     .foregroundStyle(Color.fontTertiary)
             }
         }
-        .padding(.vertical, .spacing1)
+        .padding(.vertical, .spacing4)
+        .padding(.horizontal, .spacing6)
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("chat-item-wrapper")
         .accessibilityLabel("\(chat.displayTitle)\(chat.isPinned == true ? ", pinned" : "")")

--- a/apple/OpenMates/Sources/Shared/Components/OMButtonStyles.swift
+++ b/apple/OpenMates/Sources/Shared/Components/OMButtonStyles.swift
@@ -1,5 +1,14 @@
 // OpenMates button styles matching the web app's design tokens.
-// Primary (gradient fill) and secondary (outline) variants.
+// Primary (solid orange fill, pill-shaped) and secondary (grey, pill-shaped) variants.
+
+// ─── Web source ─────────────────────────────────────────────────────
+// CSS:    frontend/packages/ui/src/styles/buttons.css
+//         button { border-radius:20px; height:41px; drop-shadow(0 4px 4px rgba(0,0,0,.25)) }
+//         button:active { scale:0.98 }
+//         button:disabled { opacity:0.6 }
+// Tokens: ColorTokens.generated.swift, SpacingTokens.generated.swift,
+//         TypographyTokens.generated.swift
+// ────────────────────────────────────────────────────────────────────
 
 import SwiftUI
 
@@ -11,48 +20,56 @@ struct OMPrimaryButtonStyle: ButtonStyle {
             .font(.omP)
             .fontWeight(.semibold)
             .foregroundStyle(Color.fontButton)
-            .padding(.horizontal, .spacing8)
-            .padding(.vertical, .spacing4)
+            .padding(.horizontal, .spacing12)
+            .padding(.vertical, .spacing8)
+            .frame(minHeight: 41)
             .background(
                 configuration.isPressed ? Color.buttonPrimaryPressed :
                     isEnabled ? Color.buttonPrimary : Color.buttonSecondary
             )
-            .clipShape(RoundedRectangle(cornerRadius: .radius3))
+            .clipShape(RoundedRectangle(cornerRadius: .radius8))
+            .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)
+            .opacity(isEnabled ? 1.0 : 0.6)
             .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
             .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
     }
 }
 
 struct OMSecondaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) var isEnabled
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.omP)
             .fontWeight(.medium)
             .foregroundStyle(Color.fontPrimary)
-            .padding(.horizontal, .spacing8)
-            .padding(.vertical, .spacing4)
-            .background(Color.grey10)
-            .clipShape(RoundedRectangle(cornerRadius: .radius3))
-            .overlay(
-                RoundedRectangle(cornerRadius: .radius3)
-                    .stroke(Color.grey30, lineWidth: 1)
-            )
+            .padding(.horizontal, .spacing12)
+            .padding(.vertical, .spacing8)
+            .frame(minHeight: 41)
+            .background(Color.buttonSecondary)
+            .clipShape(RoundedRectangle(cornerRadius: .radius8))
+            .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 4)
+            .opacity(isEnabled ? 1.0 : 0.6)
             .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
             .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
     }
 }
 
+// Stateless pill field — base style only (no focus ring).
+// Callers MUST add focus-ring behavior via .focused($isFocused) and an .overlay stroke
+// that switches from Color.grey30 (default) → Color.buttonPrimary (focused), matching
+// the fields.css pattern: border-color: var(--color-button-primary) on :focus.
 struct OMTextFieldStyle: TextFieldStyle {
     func _body(configuration: TextField<_Label>) -> some View {
         configuration
             .font(.omP)
-            .padding(.horizontal, .spacing4)
-            .padding(.vertical, .spacing3)
-            .background(Color.grey10)
-            .clipShape(RoundedRectangle(cornerRadius: .radius3))
+            .padding(.horizontal, .spacing8)
+            .padding(.vertical, .spacing6)
+            .background(Color.grey0)
+            .clipShape(RoundedRectangle(cornerRadius: .radiusFull))
             .overlay(
-                RoundedRectangle(cornerRadius: .radius3)
-                    .stroke(Color.grey30, lineWidth: 1)
+                RoundedRectangle(cornerRadius: .radiusFull)
+                    .stroke(Color.grey30, lineWidth: 2)
             )
     }
 }

--- a/frontend/apps/web_app/src/routes/(seo)/announcements/[slug]/+page.svelte
+++ b/frontend/apps/web_app/src/routes/(seo)/announcements/[slug]/+page.svelte
@@ -15,7 +15,8 @@
 
 	onMount(() => {
 		if (data.spaUrl) {
-			window.location.replace(data.spaUrl);
+			const { pathname, search, hash } = new URL(data.spaUrl);
+			window.location.replace(pathname + search + hash);
 		}
 	});
 </script>

--- a/frontend/apps/web_app/src/routes/(seo)/example/[slug]/+page.svelte
+++ b/frontend/apps/web_app/src/routes/(seo)/example/[slug]/+page.svelte
@@ -20,7 +20,8 @@
 
 	onMount(() => {
 		if (data.spaUrl) {
-			window.location.replace(data.spaUrl);
+			const { pathname, search, hash } = new URL(data.spaUrl);
+			window.location.replace(pathname + search + hash);
 		}
 	});
 </script>

--- a/frontend/apps/web_app/src/routes/(seo)/intro/[slug]/+page.svelte
+++ b/frontend/apps/web_app/src/routes/(seo)/intro/[slug]/+page.svelte
@@ -41,7 +41,11 @@
 	 */
 	onMount(() => {
 		if (data.spaUrl) {
-			window.location.replace(data.spaUrl);
+			// Use a relative redirect so prerendered pages (built with sveltekit-prerender
+			// hostname → origin always resolves to openmates.org) don't forward dev/staging
+			// visitors to the production domain.
+			const { pathname, search, hash } = new URL(data.spaUrl);
+			window.location.replace(pathname + search + hash);
 		}
 	});
 </script>

--- a/frontend/apps/web_app/src/routes/(seo)/legal/[slug]/+page.server.ts
+++ b/frontend/apps/web_app/src/routes/(seo)/legal/[slug]/+page.server.ts
@@ -1,0 +1,79 @@
+// frontend/apps/web_app/src/routes/(seo)/legal/[slug]/+page.server.ts
+//
+// Server-side loader for legal document SEO pages at /legal/{slug}.
+// Accepts slugs: privacy, terms, imprint.
+//
+// ARCHITECTURE — Static SEO page with browser redirect:
+//   1. Resolves title/description from the English i18n locale (no backend call).
+//   2. Renders HTML with OG meta tags that crawlers and link-preview bots index.
+//   3. Human browsers are redirected to the SPA via onMount in +page.svelte.
+//      The SPA then calls setActiveChat which uses replaceState to restore the
+//      /legal/{slug} path — so the URL stays clean after the redirect round-trip.
+
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { getLegalChatBySlug } from '@repo/ui';
+import { resolveI18nKey as t } from '@repo/ui/src/demo_chats/resolveI18nServer';
+import { getSiteOrigin } from '$lib/backendUrl';
+
+const LEGAL_SLUGS = ['privacy', 'terms', 'imprint'] as const;
+type LegalSlug = (typeof LEGAL_SLUGS)[number];
+
+function isLegalSlug(slug: string): slug is LegalSlug {
+	return (LEGAL_SLUGS as readonly string[]).includes(slug);
+}
+
+export const load: PageServerLoad = async ({ params, setHeaders, url }) => {
+	const { slug } = params;
+
+	if (!isLegalSlug(slug)) {
+		error(404, 'Legal document not found');
+	}
+
+	const chat = getLegalChatBySlug(slug);
+	if (!chat) {
+		error(404, 'Legal document not found');
+	}
+
+	const hostname = url.hostname;
+	const isDevHost =
+		hostname.includes('.dev.') ||
+		hostname.startsWith('dev.') ||
+		hostname.endsWith('.vercel.app') ||
+		hostname === 'localhost' ||
+		hostname === '127.0.0.1';
+
+	setHeaders({
+		'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800'
+	});
+
+	const siteOrigin = getSiteOrigin(url);
+	const canonicalUrl = `${siteOrigin}/legal/${slug}`;
+
+	const title = t(chat.title);
+	// Description is stored under metadata.legal_{slug}.description
+	const descriptionKey = `metadata.legal_${slug.replace('-', '_')}.description`;
+	const description = t(descriptionKey);
+
+	const jsonLd = {
+		'@context': 'https://schema.org',
+		'@type': 'WebPage',
+		name: title,
+		description,
+		url: canonicalUrl,
+		author: { '@type': 'Organization', name: 'OpenMates', url: siteOrigin },
+		publisher: { '@type': 'Organization', name: 'OpenMates', url: siteOrigin },
+		mainEntityOfPage: { '@type': 'WebPage', '@id': canonicalUrl }
+	};
+
+	return {
+		slug,
+		title,
+		description,
+		keywords: chat.keywords,
+		canonicalUrl,
+		jsonLd: JSON.stringify(jsonLd),
+		isDevHost,
+		spaUrl: `${siteOrigin}/#chat-id=${encodeURIComponent(chat.chat_id)}`
+	};
+};

--- a/frontend/apps/web_app/src/routes/(seo)/legal/[slug]/+page.svelte
+++ b/frontend/apps/web_app/src/routes/(seo)/legal/[slug]/+page.svelte
@@ -1,0 +1,117 @@
+<!--
+	frontend/apps/web_app/src/routes/(seo)/legal/[slug]/+page.svelte
+
+	SEO page for legal documents at /legal/{slug} (privacy, terms, imprint).
+
+	WHY (seo) ROUTE GROUP:
+	  The root +layout.svelte wraps everything in {#if loaded} (browser-only). During SSR,
+	  loaded=false so the entire page body is suppressed. This (seo) group has its own
+	  minimal +layout@.svelte that simply renders children, preserving full SSR output
+	  for crawlers and link-preview bots.
+
+	FLOW:
+	  1. Crawler / link-preview bot hits /legal/privacy → SSR renders HTML + OG tags.
+	  2. Human browser: onMount fires → redirects to SPA via /#chat-id=legal-privacy.
+	  3. SPA calls setActiveChat('legal-privacy') → replaceState restores /legal/privacy.
+	     The URL stays at /legal/privacy after the round-trip.
+-->
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	onMount(() => {
+		if (data.spaUrl) {
+			window.location.replace(data.spaUrl);
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>{data.title} — OpenMates</title>
+	<meta name="description" content={data.description} />
+	<meta name="keywords" content={data.keywords.join(', ')} />
+	<link rel="canonical" href={data.canonicalUrl} />
+	<meta name="robots" content={data.isDevHost ? 'noindex, nofollow' : 'index, follow'} />
+
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content={data.canonicalUrl} />
+	<meta property="og:title" content="{data.title} — OpenMates" />
+	<meta property="og:description" content={data.description} />
+	<meta property="og:image" content="https://openmates.org/images/og-image.jpg" />
+	<meta property="og:site_name" content="OpenMates" />
+
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:url" content={data.canonicalUrl} />
+	<meta name="twitter:title" content="{data.title} — OpenMates" />
+	<meta name="twitter:description" content={data.description} />
+	<meta name="twitter:image" content="https://openmates.org/images/og-image.jpg" />
+
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html `<script type="application/ld+json">${data.jsonLd}<` + `/script>`}
+</svelte:head>
+
+<main aria-label="{data.title} — OpenMates legal document">
+	<article>
+		<header>
+			<h1>{data.title}</h1>
+			{#if data.description}
+				<p class="description">{data.description}</p>
+			{/if}
+		</header>
+
+		<footer>
+			<a href={data.spaUrl}>Open this document in OpenMates</a>
+		</footer>
+	</article>
+</main>
+
+<style>
+	/*
+	 * Minimal styles — this page is only ever seen by crawlers.
+	 * Human users are redirected before the page renders visually.
+	 *
+	 * Note: raw color literals are intentional — this is a crawler-only
+	 * page outside the SPA theme system with no dark-mode requirement.
+	 */
+	main {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 24px;
+		font-family:
+			-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+		color: #1a1a1a; /* intentional: no theme vars — crawler-only page */
+		background: #fff; /* intentional: no theme vars — crawler-only page */
+	}
+
+	h1 {
+		font-size: 28px;
+		font-weight: 700;
+		margin: 0 0 12px;
+		color: #000; /* intentional: no theme vars — crawler-only page */
+	}
+
+	.description {
+		font-size: 16px;
+		color: #555; /* intentional: no theme vars — crawler-only page */
+		margin: 0 0 32px;
+		line-height: 1.6;
+	}
+
+	footer {
+		margin-top: 40px;
+		padding-top: 20px;
+		border-top: 1px solid #eee; /* intentional: no theme vars — crawler-only page */
+	}
+
+	footer a {
+		color: #4867cd; /* intentional: no theme vars — crawler-only page */
+		text-decoration: none;
+		font-size: 15px;
+	}
+
+	footer a:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/frontend/apps/web_app/src/routes/(seo)/legal/[slug]/+page.ts
+++ b/frontend/apps/web_app/src/routes/(seo)/legal/[slug]/+page.ts
@@ -1,0 +1,8 @@
+// frontend/apps/web_app/src/routes/(seo)/legal/[slug]/+page.ts
+//
+// SSR configuration for legal document pages at /legal/{slug}.
+// Server-rendered so crawlers and link-preview bots get OG tags.
+
+export const prerender = false;
+export const ssr = true;
+export const csr = true;

--- a/frontend/apps/web_app/src/routes/(seo)/tips/[slug]/+page.svelte
+++ b/frontend/apps/web_app/src/routes/(seo)/tips/[slug]/+page.svelte
@@ -15,7 +15,8 @@
 
 	onMount(() => {
 		if (data.spaUrl) {
-			window.location.replace(data.spaUrl);
+			const { pathname, search, hash } = new URL(data.spaUrl);
+			window.location.replace(pathname + search + hash);
 		}
 	});
 </script>

--- a/frontend/apps/web_app/src/routes/legal/imprint/+server.ts
+++ b/frontend/apps/web_app/src/routes/legal/imprint/+server.ts
@@ -1,6 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-import type { RequestHandler } from '@sveltejs/kit';
-
-export const GET: RequestHandler = async () => {
-	redirect(302, '/#chat-id=legal-imprint');
-};

--- a/frontend/apps/web_app/src/routes/legal/privacy/+server.ts
+++ b/frontend/apps/web_app/src/routes/legal/privacy/+server.ts
@@ -1,6 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-import type { RequestHandler } from '@sveltejs/kit';
-
-export const GET: RequestHandler = async () => {
-	redirect(302, '/#chat-id=legal-privacy');
-};

--- a/frontend/apps/web_app/src/routes/legal/terms/+server.ts
+++ b/frontend/apps/web_app/src/routes/legal/terms/+server.ts
@@ -1,6 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-import type { RequestHandler } from '@sveltejs/kit';
-
-export const GET: RequestHandler = async () => {
-	redirect(302, '/#chat-id=legal-terms');
-};

--- a/frontend/apps/web_app/src/routes/sitemap.xml/+server.ts
+++ b/frontend/apps/web_app/src/routes/sitemap.xml/+server.ts
@@ -16,7 +16,7 @@
 //   The robots.txt at /robots.txt already points to this sitemap.
 
 import type { RequestHandler } from './$types';
-import { getAllExampleChatData, getAllActiveNewsletterChats, newsletterKindFromChatId } from '@repo/ui';
+import { getAllExampleChatData, getAllActiveNewsletterChats, newsletterKindFromChatId, LEGAL_CHATS } from '@repo/ui';
 import docsData from '$lib/generated/docs-data.json';
 import type { DocFolder, DocStructure } from '$lib/types/docs';
 
@@ -84,6 +84,13 @@ export const GET: RequestHandler = async ({ url }) => {
   </url>`
 	];
 
+	// Legal document pages — now have SSR SEO pages at /legal/{slug}
+	const legalUrls = LEGAL_CHATS.map((chat) => `  <url>
+    <loc>${siteOrigin}/legal/${chat.slug}</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>`);
+
 	// Example chat pages (hardcoded static data — no backend fetch needed)
 	const exampleChats = getAllExampleChatData();
 	const exampleUrls = exampleChats.map((chat) => {
@@ -126,6 +133,7 @@ export const GET: RequestHandler = async ({ url }) => {
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${staticUrls.join('\n')}
 ${docsUrls.join('\n')}
+${legalUrls.join('\n')}
 ${exampleUrls.join('\n')}
 ${newsletterUrls.join('\n')}
 </urlset>`;

--- a/frontend/apps/web_app/tests/seo-demo-chat.spec.ts
+++ b/frontend/apps/web_app/tests/seo-demo-chat.spec.ts
@@ -94,20 +94,24 @@ test.describe('SEO example chat pages', () => {
 	// 2. BROWSER REDIRECT (human users see this)
 	// =========================================================================
 
-	test('individual example chat page redirects browser to SPA with correct chat-id', async ({
+	test('individual example chat page redirects browser to SPA and restores semantic URL', async ({
 		page
 	}) => {
 		test.setTimeout(30000);
 
 		await page.goto(EXAMPLE_PATH, { waitUntil: 'commit' });
 
-		// Wait for the redirect to fire (onMount is fast but needs a tick)
-		await page.waitForURL((url: URL) => url.hash.includes('chat-id='), { timeout: 10000 });
+		// The SSR page fires window.location.replace('/#chat-id=...') in onMount, then
+		// the SPA calls setActiveChat which uses replaceState to restore the semantic path.
+		// Wait for the final URL to settle at the semantic path (no hash).
+		await page.waitForURL(
+			(url: URL) => url.pathname === EXAMPLE_PATH && !url.hash,
+			{ timeout: 15000 }
+		);
 
-		const url = page.url();
-		// Should be on the SPA root (path is / or just the hash)
-		const parsedUrl = new URL(url);
-		expect(parsedUrl.pathname).toBe('/');
+		const parsedUrl = new URL(page.url());
+		expect(parsedUrl.pathname).toBe(EXAMPLE_PATH);
+		expect(parsedUrl.hash).toBe('');
 	});
 
 	// =========================================================================

--- a/frontend/packages/ui/src/components/ActiveChat.svelte
+++ b/frontend/packages/ui/src/components/ActiveChat.svelte
@@ -9557,9 +9557,9 @@ console.debug('[ActiveChat] Loading child website embeds for web search fullscre
                                     </button>
                                 </div>
                             {/if}
-                            {#if !showWelcome}
+                            {#if !showWelcome && !(currentChat?.chat_id && isPublicChat(currentChat.chat_id))}
                                 <!-- Share button - opens settings menu with share submenu -->
-                                <!-- Use same wrapper design as new chat button -->
+                                <!-- Hidden for intro, example, and legal chats (public/static chats the user doesn't own) -->
                                 <div class="new-chat-button-wrapper">
                                     <button
                                         class="clickable-icon icon_share top-button"

--- a/frontend/packages/ui/src/components/ChatHeader.svelte
+++ b/frontend/packages/ui/src/components/ChatHeader.svelte
@@ -82,6 +82,9 @@
     /** Called when the user clicks the highlights pill. */
     onHighlightJump = undefined,
     autoplayVideo = false,
+    /** When true, shows a large Sign Up CTA below the title inside the banner.
+     *  Only used for intro chats shown to non-authenticated users. */
+    showSignupCta = false,
   }: {
     title?: string;
     category?: string | null;
@@ -107,6 +110,8 @@
     onHighlightJump?: (() => void) | undefined;
     /** When true, auto-starts video playback on mount (used by &autoplay-video deep link). */
     autoplayVideo?: boolean;
+    /** When true, shows a large Sign Up CTA below the title inside the banner. */
+    showSignupCta?: boolean;
   } = $props();
 
   /** True when the static-image slideshow should render inside the media frame. */
@@ -527,6 +532,16 @@
             <span class="example-chat-badge" data-testid="example-chat-badge">{$text('chat.header.example_chat')}</span>
           {/if}
         </div>
+
+        {#if showSignupCta}
+          <button
+            class="banner-signup-button"
+            data-testid="banner-signup-button"
+            onclick={() => window.dispatchEvent(new CustomEvent('openSignupInterface'))}
+          >
+            {$text('signup.sign_up')}
+          </button>
+        {/if}
       </div>
     {:else}
       <div class="loaded-content">
@@ -1209,12 +1224,6 @@
       right: calc(50% - 180px - 70px);
     }
 
-    .media-frame {
-      height: auto;
-      width: calc(100% - 60px);
-      max-width: unset;
-    }
-
     .video-play-btn {
       width: 56px !important;
       height: 56px !important;
@@ -1523,5 +1532,45 @@
     position: static;
     padding: 0;
     opacity: 1;
+  }
+
+  /* Mobile: switch from height%-driven to width-driven sizing so aspect-ratio:16/9
+     is honored. This block must come AFTER the base .media-frame rule above so the
+     mobile override wins in the cascade. */
+  @media (max-width: 730px) {
+    .media-frame {
+      height: auto;
+      width: 100%;
+      max-width: 100%;
+      max-height: unset;
+    }
+  }
+
+  /* Sign-up CTA rendered inside the banner below the title, for non-auth intro chats. */
+  .banner-signup-button {
+    all: unset;
+    margin-top: var(--spacing-2);
+    padding: var(--spacing-5) var(--spacing-10);
+    border-radius: var(--radius-3);
+    background-color: var(--color-button-primary);
+    color: white;
+    cursor: pointer;
+    font-size: var(--font-size-lg);
+    font-weight: 700;
+    white-space: nowrap;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    transition: transform var(--duration-normal) var(--easing-default), box-shadow var(--duration-normal) var(--easing-default);
+    pointer-events: auto;
+  }
+
+  .banner-signup-button:hover {
+    transform: scale(1.03);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+  }
+
+  .banner-signup-button:active {
+    background-color: var(--color-button-primary-pressed);
+    transform: scale(0.97);
+    box-shadow: none;
   }
 </style>

--- a/frontend/packages/ui/src/components/ChatHeader.svelte
+++ b/frontend/packages/ui/src/components/ChatHeader.svelte
@@ -1210,8 +1210,9 @@
     }
 
     .media-frame {
-      height: 60%;
-      max-width: calc(100% - 60px);
+      height: auto;
+      width: calc(100% - 60px);
+      max-width: unset;
     }
 
     .video-play-btn {

--- a/frontend/packages/ui/src/components/ChatHeader.svelte
+++ b/frontend/packages/ui/src/components/ChatHeader.svelte
@@ -539,7 +539,7 @@
             data-testid="banner-signup-button"
             onclick={() => window.dispatchEvent(new CustomEvent('openSignupInterface'))}
           >
-            {$text('signup.sign_up')}
+            {$text('signup.sign_up')} / {$text('login.login')}
           </button>
         {/if}
       </div>

--- a/frontend/packages/ui/src/components/ChatHistory.svelte
+++ b/frontend/packages/ui/src/components/ChatHistory.svelte
@@ -57,6 +57,7 @@
   import { text } from '@repo/ui'; // Used for compression summary UI labels
   import { chatDebugStore } from '../stores/chatDebugStore';
   import { authStore } from '../stores/authStore';
+  import { introBannerVisible } from '../stores/uiStateStore';
 
   type AppCardData = {
     component: new (...args: unknown[]) => SvelteComponent;
@@ -469,6 +470,32 @@
 
   // Reference to the chat history container for scrolling.
   let container: HTMLDivElement;
+
+  // Bound to the chat-header-wrapper div; used by the IntersectionObserver below.
+  let headerWrapperEl = $state<HTMLElement | null>(null);
+
+  // True only for non-auth users on intro chats — shows CTA inside the banner.
+  const showSignupCta = $derived(
+    !$authStore.isAuthenticated && !!currentChatId && isDemoChat(currentChatId)
+  );
+
+  // Keep introBannerVisible in sync with whether the banner is visible in the viewport.
+  // When it is visible, Header hides its own signup button so there's no duplicate CTA.
+  $effect(() => {
+    if (!headerWrapperEl || !showSignupCta) {
+      introBannerVisible.set(false);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => { introBannerVisible.set(entry.isIntersecting); },
+      { threshold: 0.1 }
+    );
+    observer.observe(headerWrapperEl);
+    return () => {
+      observer.disconnect();
+      introBannerVisible.set(false);
+    };
+  });
 
   // Props using Svelte 5 runes mode
   let {
@@ -1620,7 +1647,7 @@
          so it spans the full width regardless of the .chat-history-content max-width.
          Scrolls naturally with the content because it lives in the scroll container. -->
     {#if showChatHeader}
-        <div class="chat-header-wrapper">
+        <div class="chat-header-wrapper" bind:this={headerWrapperEl}>
             <ChatHeader
                 title={chatTitle}
                 category={chatCategory}
@@ -1636,20 +1663,8 @@
                 {highlightStats}
                 onHighlightJump={handleHighlightJump}
                 {autoplayVideo}
+                {showSignupCta}
             />
-        </div>
-    {/if}
-
-    <!-- Sign-up CTA below the video banner for non-authenticated users on intro chats.
-         Scrolls away naturally as the user reads messages, at which point the header button takes over. -->
-    {#if !$authStore.isAuthenticated && currentChatId && isDemoChat(currentChatId)}
-        <div class="video-signup-cta">
-            <button
-                class="video-signup-button"
-                onclick={() => window.dispatchEvent(new CustomEvent('openSignupInterface'))}
-            >
-                {$text('signup.sign_up')}
-            </button>
         </div>
     {/if}
 
@@ -2060,33 +2075,4 @@
     width: calc(100% + 20px);
   }
 
-  .video-signup-cta {
-    display: flex;
-    justify-content: center;
-    padding: var(--spacing-6) var(--spacing-4);
-  }
-
-  .video-signup-button {
-    all: unset;
-    padding: var(--spacing-4) var(--spacing-8);
-    border-radius: var(--radius-3);
-    background-color: var(--color-button-primary);
-    color: white;
-    cursor: pointer;
-    font-size: var(--font-size-base);
-    font-weight: 600;
-    transition: all var(--duration-normal) var(--easing-default);
-    white-space: nowrap;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  }
-
-  .video-signup-button:hover {
-    transform: scale(1.02);
-  }
-
-  .video-signup-button:active {
-    background-color: var(--color-button-primary-pressed);
-    transform: scale(0.98);
-    box-shadow: none;
-  }
 </style>

--- a/frontend/packages/ui/src/components/ChatHistory.svelte
+++ b/frontend/packages/ui/src/components/ChatHistory.svelte
@@ -20,7 +20,7 @@
   import { editMessageStore } from '../stores/editMessageStore';
   import { locale } from 'svelte-i18n';
   import { contentCache } from '../utils/contentCache';
-  import { getDemoMessages, isPublicChat, DEMO_CHATS, LEGAL_CHATS } from '../demo_chats'; // Import demo chat utilities for re-fetching on locale change
+  import { getDemoMessages, isPublicChat, isDemoChat, DEMO_CHATS, LEGAL_CHATS } from '../demo_chats'; // Import demo chat utilities for re-fetching on locale change
   import { messageHighlightStore } from '../stores/messageHighlightStore';
   import type { 
     AppSettingsMemoriesResponseContent,
@@ -56,6 +56,7 @@
   import { formatDisplayName, getAppGradient } from '../services/chatSyncServiceHandlersAppSettings';
   import { text } from '@repo/ui'; // Used for compression summary UI labels
   import { chatDebugStore } from '../stores/chatDebugStore';
+  import { authStore } from '../stores/authStore';
 
   type AppCardData = {
     component: new (...args: unknown[]) => SvelteComponent;
@@ -1639,6 +1640,19 @@
         </div>
     {/if}
 
+    <!-- Sign-up CTA below the video banner for non-authenticated users on intro chats.
+         Scrolls away naturally as the user reads messages, at which point the header button takes over. -->
+    {#if !$authStore.isAuthenticated && currentChatId && isDemoChat(currentChatId)}
+        <div class="video-signup-cta">
+            <button
+                class="video-signup-button"
+                onclick={() => window.dispatchEvent(new CustomEvent('openSignupInterface'))}
+            >
+                {$text('signup.sign_up')}
+            </button>
+        </div>
+    {/if}
+
     <!-- Floating up/down arrows for highlight navigation. Only visible when
          more than one highlight exists and the user has opened navigation. -->
     <HighlightNavigationOverlay anchorRect={overlayAnchorRect} />
@@ -2044,5 +2058,35 @@
     margin-inline-end: -10px;
     /* Full width including the cancelled side padding */
     width: calc(100% + 20px);
+  }
+
+  .video-signup-cta {
+    display: flex;
+    justify-content: center;
+    padding: var(--spacing-6) var(--spacing-4);
+  }
+
+  .video-signup-button {
+    all: unset;
+    padding: var(--spacing-4) var(--spacing-8);
+    border-radius: var(--radius-3);
+    background-color: var(--color-button-primary);
+    color: white;
+    cursor: pointer;
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    transition: all var(--duration-normal) var(--easing-default);
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  }
+
+  .video-signup-button:hover {
+    transform: scale(1.02);
+  }
+
+  .video-signup-button:active {
+    background-color: var(--color-button-primary-pressed);
+    transform: scale(0.98);
+    box-shadow: none;
   }
 </style>

--- a/frontend/packages/ui/src/components/Header.svelte
+++ b/frontend/packages/ui/src/components/Header.svelte
@@ -9,7 +9,7 @@
     import { text } from '@repo/ui';
     import { isInSignupProcess, isLoggingOut } from '../stores/signupState'; // Import the signup state and logging out state
     import { panelState } from '../stores/panelStateStore'; // Import panel state store
-    import { loginInterfaceOpen } from '../stores/uiStateStore'; // Import mobile view state and login interface visibility
+    import { loginInterfaceOpen, introBannerVisible } from '../stores/uiStateStore'; // Import mobile view state and login interface visibility
     import { authStore } from '../stores/authStore'; // Import auth store to check login status
     import { demoMode } from '../stores/demoModeStore';
 
@@ -356,7 +356,7 @@
                 {#if !docsMode}
                     <div
                         class="right-section"
-                        class:hidden={context !== 'webapp' || $authStore.isAuthenticated || $loginInterfaceOpen}
+                        class:hidden={context !== 'webapp' || $authStore.isAuthenticated || $loginInterfaceOpen || $introBannerVisible}
                     >
                         <button
                             class="login-signup-button"

--- a/frontend/packages/ui/src/components/Header.svelte
+++ b/frontend/packages/ui/src/components/Header.svelte
@@ -707,11 +707,14 @@
         position: absolute;
         right: 50px; /* Space for settings menu button */
         top: 50%; /* Center vertically */
-        transform: translateY(-50%); /* Center vertically */
+        transform: translateY(-50%) translateX(0);
         display: flex;
         align-items: center;
         gap: 0.75rem; /* Add gap between sign in button and language icon */
-        transition: opacity var(--duration-normal) var(--easing-default), visibility var(--duration-normal) var(--easing-default);
+        transition:
+            opacity var(--duration-normal) var(--easing-default),
+            visibility var(--duration-normal) var(--easing-default),
+            transform var(--duration-normal) var(--easing-default);
         margin-right: var(--spacing-5);
         /* Absolutely positioned so it doesn't affect header height, but we keep it rendered for smooth transitions */
     }
@@ -721,6 +724,7 @@
         opacity: 0;
         visibility: hidden;
         pointer-events: none; /* Prevent interaction when hidden */
+        transform: translateY(-50%) translateX(16px);
     }
 
     .login-signup-button {

--- a/frontend/packages/ui/src/components/Notification.svelte
+++ b/frontend/packages/ui/src/components/Notification.svelte
@@ -215,6 +215,7 @@
         /* Figma design: 430px or 100% viewport width, with 5px margin on smaller screens */
         width: 430px;
         max-width: calc(100vw - 10px);
+        overflow: hidden;
         
         /* Base styling */
         padding: var(--spacing-6) var(--spacing-8);

--- a/frontend/packages/ui/src/components/enter_message/MentionDropdown.svelte
+++ b/frontend/packages/ui/src/components/enter_message/MentionDropdown.svelte
@@ -544,8 +544,8 @@
         background: var(--color-grey-blue);
         border-radius: var(--radius-7);
         box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-        min-width: 380px;
-        max-width: 450px;
+        min-width: min(380px, calc(100vw - 10px));
+        max-width: calc(100vw - 10px);
         max-height: 420px;
         overflow-y: auto;
         overflow-x: hidden;

--- a/frontend/packages/ui/src/services/chatUrlService.ts
+++ b/frontend/packages/ui/src/services/chatUrlService.ts
@@ -49,6 +49,8 @@ export function isOnSemanticChatPath(): boolean {
  */
 export function getSemanticUrlForChat(chatId: string): string | null {
 	if (chatId.startsWith('demo-')) {
+		// demo-for-everyone is the default welcome state — no semantic URL
+		if (chatId === 'demo-for-everyone') return null;
 		return `/intro/${chatId.slice('demo-'.length)}`;
 	}
 	if (chatId.startsWith('example-')) {

--- a/frontend/packages/ui/src/services/chatUrlService.ts
+++ b/frontend/packages/ui/src/services/chatUrlService.ts
@@ -1,27 +1,73 @@
 /**
  * Chat URL Service
- * 
+ *
  * Manages URL-based chat navigation with privacy-first approach.
- * 
- * Current Behavior (Privacy-First):
- * - Deep linking is supported: opening a URL with #chat-id=xxx will load that chat
- * - URL is immediately cleared after loading the deep-linked chat
- * - Normal chat navigation does NOT update the URL (no automatic URL updates)
- * - This prevents accidental sharing of chat history via URL
- * 
- * Privacy Features:
- * - Uses SvelteKit's replaceState() to update URL WITHOUT adding browser history entries
- * - Hash fragments (#) are never sent to server, providing server-side privacy
- * - Combined approach: Private from both server AND browser history
- * 
- * Use Cases:
- * - Share direct links to specific chats (recipient-initiated only)
- * - Deep link to chats from external sources
- * - URL is cleared immediately after loading to prevent accidental sharing
+ *
+ * Public chats (intro, example, announcement, tips, legal) get semantic paths
+ * (e.g. /intro/for-everyone, /announcements/introducing-openmates-v09) so that
+ * shared links show proper OG previews — those paths have SSR SEO pages.
+ *
+ * Private chats still use the hash fragment (#chat-id=xxx) which is never sent
+ * to the server, preserving server-side privacy.
  */
 
 import { replaceState } from '$app/navigation';
 import { browser } from '$app/environment';
+import { getExampleChatData } from '../demo_chats/exampleChatStore';
+import { getNewsletterChatById } from '../demo_chats/newsletterChatStore';
+
+// Path prefixes that correspond to public-chat SEO routes.
+// Used to detect when the URL should be reverted to / on navigation away.
+export const SEMANTIC_CHAT_PATH_PREFIXES = [
+	'/intro/',
+	'/example/',
+	'/announcements/',
+	'/tips/',
+	'/legal/'
+] as const;
+
+/**
+ * Returns true when the current browser path is a public-chat semantic path
+ * (i.e. one that should revert to / when the user navigates to a private chat).
+ */
+export function isOnSemanticChatPath(): boolean {
+	if (typeof window === 'undefined') return false;
+	const path = window.location.pathname;
+	return SEMANTIC_CHAT_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+/**
+ * Map a chat ID to its shareable semantic URL path.
+ * Returns null for private chats (they stay on the hash).
+ *
+ * Mappings:
+ *   demo-*          → /intro/{slug}
+ *   example-*       → /example/{slug}   (slug from ExampleChat.slug)
+ *   announcements-* → /announcements/{slug}
+ *   tips-*          → /tips/{slug}
+ *   legal-*         → /legal/{slug}
+ */
+export function getSemanticUrlForChat(chatId: string): string | null {
+	if (chatId.startsWith('demo-')) {
+		return `/intro/${chatId.slice('demo-'.length)}`;
+	}
+	if (chatId.startsWith('example-')) {
+		const data = getExampleChatData(chatId);
+		return data ? `/example/${data.slug}` : null;
+	}
+	if (chatId.startsWith('announcements-')) {
+		const chat = getNewsletterChatById(chatId);
+		return chat ? `/announcements/${chat.slug}` : null;
+	}
+	if (chatId.startsWith('tips-')) {
+		const chat = getNewsletterChatById(chatId);
+		return chat ? `/tips/${chat.slug}` : null;
+	}
+	if (chatId.startsWith('legal-')) {
+		return `/legal/${chatId.slice('legal-'.length)}`;
+	}
+	return null;
+}
 
 /**
  * Update the browser URL to reflect the currently active chat
@@ -87,20 +133,4 @@ export function getChatIdFromUrl(): string | null {
 	}
 }
 
-/**
- * Clear the chat ID from the URL
- * Convenience function that calls updateChatUrl(null)
- */
-function clearChatUrl(): void {
-	updateChatUrl(null);
-}
-
-/**
- * Check if a chat URL is currently set
- * 
- * @returns True if a chat ID is present in the URL
- */
-function hasChatUrl(): boolean {
-	return getChatIdFromUrl() !== null;
-}
 

--- a/frontend/packages/ui/src/stores/activeChatStore.ts
+++ b/frontend/packages/ui/src/stores/activeChatStore.ts
@@ -5,13 +5,18 @@
  * This ensures the chat list can correctly highlight the active chat even when
  * the Chats panel is closed and reopened.
  *
- * Also manages URL hash to allow users to share/bookmark specific chats.
- * Format: #chat-id={chatId}
+ * URL management (privacy-first):
+ *   - Public chats (intro, example, announcements, tips, legal) → semantic path
+ *     e.g. /intro/for-everyone, /announcements/introducing-openmates-v09
+ *     Shared links hit an SSR page with full OG tags, then redirect to the SPA.
+ *   - Private chats → hash fragment (#chat-id=xxx), never sent to the server.
+ *   All updates use replaceState — no browser history entries are added.
  */
 
 import { writable } from "svelte/store";
 import { browser } from "$app/environment";
 import { replaceState } from "$app/navigation";
+import { getSemanticUrlForChat, isOnSemanticChatPath } from "../services/chatUrlService";
 
 /**
  * Store to track when deep link processing is happening
@@ -28,33 +33,53 @@ let lastProgrammaticHashUpdate = 0;
 const PROGRAMMATIC_UPDATE_WINDOW_MS = 100; // Window to ignore hashchange events after programmatic update
 
 /**
- * Update the URL hash with the chat ID
- * Format: #chat-id={chatId}
- * Only updates if the hash doesn't already match to prevent unnecessary hashchange events
+ * Update the browser URL to reflect the active chat.
+ *
+ * Public chats (intro, example, announcements, tips, legal) get a semantic path
+ * (e.g. /intro/for-everyone) so shared links hit an SSR page with OG tags.
+ * Private chats use the hash fragment (#chat-id=xxx) which is never sent to the
+ * server, preserving privacy.
+ *
+ * Always uses replaceState — no browser history entries are added.
  */
 function updateUrlHash(chatId: string | null) {
-  if (!browser) return; // Only update URL in browser environment
-
-  const currentHash = window.location.hash;
-  const expectedHash = chatId ? `#chat-id=${chatId}` : "";
-
-  // Only update if hash doesn't already match (prevents unnecessary hashchange events)
-  if (currentHash === expectedHash) {
-    return; // Hash already matches, no update needed
-  }
-
-  // Record timestamp of programmatic update
-  lastProgrammaticHashUpdate = Date.now();
+  if (!browser) return;
 
   if (chatId) {
-    // Set hash to #chat-id={chatId} (chat-only; any open embed will update hash itself via setActiveEmbed)
-    window.location.hash = `chat-id=${chatId}`;
-  } else {
-    // Clear hash if no chat is selected.
-    // Handle both plain #chat-id= and combined #chat-id=X&embed-id=Y formats.
-    if (window.location.hash.startsWith("#chat-id=")) {
-      replaceState(window.location.pathname + window.location.search, {});
+    const semanticUrl = getSemanticUrlForChat(chatId);
+
+    if (semanticUrl) {
+      // Public chat → update path to semantic URL (no hash, no history entry)
+      if (window.location.pathname !== semanticUrl) {
+        replaceState(semanticUrl, {});
+      }
+      return;
     }
+
+    // Private chat → use hash fragment.
+    // If we're currently on a semantic path, move back to root first so the hash
+    // doesn't get appended to e.g. /intro/for-everyone.
+    const expectedHash = `#chat-id=${chatId}`;
+    if (isOnSemanticChatPath()) {
+      replaceState(`/${expectedHash}`, {});
+      return;
+    }
+
+    const currentHash = window.location.hash;
+    if (currentHash !== expectedHash) {
+      lastProgrammaticHashUpdate = Date.now();
+      window.location.hash = `chat-id=${chatId}`;
+    }
+    return;
+  }
+
+  // Clearing: go back to root (no hash, no semantic path)
+  if (isOnSemanticChatPath()) {
+    replaceState("/", {});
+    return;
+  }
+  if (window.location.hash.startsWith("#chat-id=")) {
+    replaceState(window.location.pathname + window.location.search, {});
   }
 }
 

--- a/frontend/packages/ui/src/stores/uiStateStore.ts
+++ b/frontend/packages/ui/src/stores/uiStateStore.ts
@@ -41,7 +41,7 @@ export const isMobileView = readable<boolean>(false, (set) => {
  * A readable store that tracks whether the viewport should auto-open
  * the chats panel by default.
  */
-const isChatsDefaultOpenViewport = readable<boolean>(false, (set) => {
+export const isChatsDefaultOpenViewport = readable<boolean>(false, (set) => {
   if (!browser) {
     set(false);
     return;
@@ -67,6 +67,10 @@ export const sessionExpiredWarning = writable<boolean>(false);
 // Store to track if login interface is currently open/visible
 // Used to hide header buttons (Sign In button and menu button) when login is shown
 export const loginInterfaceOpen = writable<boolean>(false);
+
+// True when the intro chat header banner is intersecting the viewport.
+// Used to hide the header Sign Up button while the banner CTA is visible.
+export const introBannerVisible = writable<boolean>(false);
 
 // --- Potentially add other global UI states here in the future ---
 // e.g., theme, density, etc.


### PR DESCRIPTION
## Summary

This PR delivers semantic URL routing for all public chat types, a redesigned signup CTA flow with scroll-based header visibility, and a major Apple UI update bringing the iOS/macOS app to full parity with the web — including ChatBannerView, i18n enforcement, and web-source reference blocks across all Swift views.

## Features

**SEO & Routing**
- Public chats (intro/example/announcements/tips/legal) now update the browser URL to their semantic path when opened in the SPA
- New SEO server-side routes for legal pages (`[slug]/+page.server.ts`)
- Sitemap updated to include new semantic URL paths

**Web — Signup CTA**
- Signup CTA moved into ChatHeader banner (below title), larger and contextually visible
- IntersectionObserver in ChatHistory drives `introBannerVisible` store; header signup button hides/shows based on banner visibility
- Smooth slide-from-right + fade animation on the header signup button
- Hide share button for public chats (intro/example/legal)

**Apple — UI Parity**
- `ChatBannerView` created to match `ChatHeader.svelte` (gradient banner, shimmer loading state)
- Demo-for-everyone chat opens by default on cold-boot, matching `+page.svelte` behavior
- All `INTRO_CHATS`, legal chats, and example chats added to `loadDemoChats()`
- `InputActionButtons` redesigned to match `ActionButtons.svelte` (files/maps/mic left, send right)
- Web-source reference blocks (`// ─── Web source ───`) added across all Swift UI view files

## Bug Fixes

- **OPE-447:** Fix 16:9 video aspect ratio on mobile — switch to width-based sizing so aspect ratio holds on narrow viewports
- **OPE-447:** Signup/login button now shows "Sign up / Login" instead of "Sign up" only
- **SEO:** Redirects in SEO pages now use relative URLs (strip origin) to avoid environment mismatches in staging vs prod
- **SEO:** Skip semantic URL rewrite for the `for-everyone` chat (canonical path stays as-is)
- **MentionDropdown:** `min-width` was fixed at 380px — now clamped to viewport width, fixing overflow on 375px screens
- **Notification:** Add `overflow: hidden` to prevent content escaping max-width container
- **Apple:** Fix `NewChatView` / `ChatView` input bar border — `grey30` stroke (was invisible `grey0`)
- **Apple:** Fix `streamingBanner` background — `grey0` (was `grey10`)
- **Apple:** Fix sidebar native chrome — `.scrollContentBackground(.hidden)` + `Color.grey0` background

## Improvements

- **Apple i18n:** Full enforcement — zero hardcoded English strings; all user-visible text goes through `AppStrings` / `LocalizationManager`
- **Apple:** `AppStrings` accessors added for all new chat titles (who_develops_openmates, announcements, legal slugs, example chats)
- **Chore:** `apple-ui.md` rules file added — documents web-source-of-truth mandate, token usage, and Swift ↔ Svelte file mapping