### PR TITLE
fix: CLI pair login, encryption key race, embed markdown, and CI prerelease bump

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -44,7 +44,14 @@ jobs:
       - name: Bump prerelease version (dev only)
         if: github.ref == 'refs/heads/dev'
         working-directory: frontend/packages/openmates-cli
-        run: npm version prerelease --preid alpha --no-git-tag-version
+        run: |
+          # Base the bump on the highest published alpha, not package.json,
+          # so re-runs after an uncommitted version bump don't collide.
+          PUBLISHED=$(npm view openmates@alpha version 2>/dev/null || echo "")
+          if [ -n "$PUBLISHED" ]; then
+            npm version "$PUBLISHED" --no-git-tag-version --allow-same-version
+          fi
+          npm version prerelease --preid alpha --no-git-tag-version
 
       - name: Publish to npm (stable)
         if: github.ref == 'refs/heads/main'

--- a/backend/core/api/app/routes/auth_routes/auth_pair.py
+++ b/backend/core/api/app/routes/auth_routes/auth_pair.py
@@ -20,7 +20,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import re
 import secrets
@@ -133,8 +132,6 @@ class PairCredentialsResponse(BaseModel):
     lookup_hash: str
     user_email_salt: str
     hashed_email: str  # SHA256(email) — needed by /auth/login for user lookup
-    encrypted_key: str
-    salt: str
 
 
 class PairCompleteRequest(BaseModel):
@@ -272,10 +269,10 @@ async def pair_credentials(
     """
     Return pair-login credentials for the authenticated authorizing device.
 
-    lookup_hashes and user_email_salt come from the cached User object.
-    encrypted_key and salt are stored in the encryption_keys collection (keyed by
-    hashed_user_id = SHA256(user_uuid)) — NOT on the directus_users record — so we
-    fetch them via get_encryption_key() rather than from current_user fields.
+    lookup_hash and user_email_salt come from the cached User object.
+    hashed_email is fetched from the user profile cache / Directus fallback.
+    The master key is exported client-side and placed in the encrypted bundle;
+    this endpoint only provides the identifiers needed for /auth/login.
     """
     lookup_hashes = current_user.lookup_hashes or []
     lookup_hash = next(
@@ -305,39 +302,10 @@ async def pair_credentials(
             detail="Pair login credentials not available for current session",
         )
 
-    # encrypted_key + salt live in the encryption_keys collection, not on directus_users.
-    hashed_user_id = hashlib.sha256(current_user.id.encode()).hexdigest()
-    encryption_key_data = await directus_service.get_encryption_key(hashed_user_id, "password")
-
-    if not encryption_key_data:
-        logger.warning(
-            "pair/credentials: no password encryption key found for user %s",
-            current_user.id[:8],
-        )
-        raise HTTPException(
-            status_code=409,
-            detail="Pair login credentials not available for current session",
-        )
-
-    encrypted_key = encryption_key_data.get("encrypted_key")
-    salt = encryption_key_data.get("salt")
-
-    if not encrypted_key or not salt:
-        logger.warning(
-            "pair/credentials: encryption key record incomplete for user %s",
-            current_user.id[:8],
-        )
-        raise HTTPException(
-            status_code=409,
-            detail="Pair login credentials not available for current session",
-        )
-
     return PairCredentialsResponse(
         lookup_hash=lookup_hash,
         user_email_salt=current_user.user_email_salt,
         hashed_email=hashed_email,
-        encrypted_key=encrypted_key,
-        salt=salt,
     )
 
 

--- a/frontend/packages/openmates-cli/src/client.ts
+++ b/frontend/packages/openmates-cli/src/client.ts
@@ -2780,66 +2780,87 @@ export class OpenMatesClient {
     let totalChatCount = 0;
 
     try {
+      // Send phase:all so the server runs all sync phases over a single WS
+      // connection and terminates with phased_sync_complete.
       ws.send("phased_sync_request", {
-        phase: "phase3",
+        phase: "all",
         client_chat_versions: clientChatVersions,
         client_chat_ids: clientChatIds,
         client_embed_ids: clientEmbedIds,
       });
-      const initial = await ws.waitForMessage("phase_3_last_100_chats_ready");
-      const initialPayload = initial.payload as {
-        chats?: Array<Record<string, unknown>>;
-        total_chat_count?: number;
-        embeds?: Record<string, unknown>[];
-        embed_keys?: Record<string, unknown>[];
-        new_chat_suggestions?: Record<string, unknown>[];
-      };
 
-      const firstChats = initialPayload.chats ?? [];
-      for (const wrapper of firstChats) {
-        const details = wrapper.chat_details as
-          | Record<string, unknown>
-          | undefined;
-        if (!details || typeof details.id !== "string") continue;
-        const messages = Array.isArray(wrapper.messages)
-          ? (wrapper.messages as string[])
-          : [];
-        chats.push({ details, messages });
-      }
+      // Collect every frame until phased_sync_complete (or 90s timeout).
+      // Processing inline rather than per-event avoids race conditions where
+      // a fast server response could arrive before a waitForMessage listener
+      // is registered.
+      const frames = await ws.collectMessages("phased_sync_complete", 90_000);
 
-      totalChatCount = initialPayload.total_chat_count ?? firstChats.length;
-      embeds = initialPayload.embeds ?? [];
-      embedKeys = initialPayload.embed_keys ?? [];
-      newChatSuggestions = initialPayload.new_chat_suggestions ?? [];
+      // Messages keyed by chat_id — merged from phase_1b and background_message_sync.
+      const messagesByChatId = new Map<string, string[]>();
 
-      // Load remaining chats if there are more
-      let offset = firstChats.length;
-      while (offset < totalChatCount) {
-        ws.send("load_more_chats", { offset, limit: 50 });
-        const more = await ws.waitForMessage("load_more_chats_response");
-        const payload = more.payload as {
-          chats?: Array<Record<string, unknown>>;
-          has_more?: boolean;
-          embeds?: Record<string, unknown>[];
-          embed_keys?: Record<string, unknown>[];
-        };
-        const batch = payload.chats ?? [];
-        for (const wrapper of batch) {
-          const details = wrapper.chat_details as
-            | Record<string, unknown>
-            | undefined;
-          if (!details || typeof details.id !== "string") continue;
-          const messages = Array.isArray(wrapper.messages)
-            ? (wrapper.messages as string[])
-            : [];
-          chats.push({ details, messages });
+      for (const frame of frames) {
+        if (frame.type === "phase_1_last_chat_ready") {
+          // Primary source for new_chat_suggestions (not included in phase2/3).
+          const p = frame.payload as {
+            new_chat_suggestions?: Record<string, unknown>[];
+          };
+          newChatSuggestions = p.new_chat_suggestions ?? [];
+
+        } else if (frame.type === "phase_1b_chat_content_ready") {
+          // Messages + embeds for the most recent ~11 chats.
+          const p = frame.payload as {
+            chats?: Array<{ chat_id: string; messages: string[] | null }>;
+            embeds?: Record<string, unknown>[];
+            embed_keys?: Record<string, unknown>[];
+          };
+          for (const c of (p.chats ?? [])) {
+            if (c.chat_id && Array.isArray(c.messages) && c.messages.length > 0) {
+              messagesByChatId.set(c.chat_id, c.messages);
+            }
+          }
+          if (p.embeds) embeds.push(...p.embeds);
+          if (p.embed_keys) embedKeys.push(...p.embed_keys);
+
+        } else if (frame.type === "phase_2_last_20_chats_ready") {
+          // Metadata (no messages) for up to 100 chats + authoritative total count.
+          const p = frame.payload as {
+            chats?: Array<Record<string, unknown>>;
+            total_chat_count?: number;
+          };
+          totalChatCount = p.total_chat_count ?? 0;
+          for (const wrapper of (p.chats ?? [])) {
+            const details = wrapper.chat_details as Record<string, unknown> | undefined;
+            if (!details || typeof details.id !== "string") continue;
+            chats.push({ details, messages: [] });
+          }
+
+        } else if (frame.type === "background_message_sync") {
+          // Chunked message batches for chats not already covered by phase_1b.
+          const p = frame.payload as {
+            chats?: Array<{ chat_id: string; messages: string[] }>;
+            embeds?: Record<string, unknown>[];
+            embed_keys?: Record<string, unknown>[];
+          };
+          for (const c of (p.chats ?? [])) {
+            if (c.chat_id && Array.isArray(c.messages) && c.messages.length > 0) {
+              messagesByChatId.set(c.chat_id, c.messages);
+            }
+          }
+          if (p.embeds) embeds.push(...p.embeds);
+          if (p.embed_keys) embedKeys.push(...p.embed_keys);
         }
-        // Merge additional embeds/embed_keys from paginated responses
-        if (payload.embeds) embeds.push(...payload.embeds);
-        if (payload.embed_keys) embedKeys.push(...payload.embed_keys);
-        offset += batch.length;
-        if (!payload.has_more || batch.length === 0) break;
       }
+
+      // Attach collected messages to their chat metadata entries.
+      for (const chat of chats) {
+        const id = typeof chat.details.id === "string" ? chat.details.id : "";
+        const msgs = messagesByChatId.get(id);
+        if (msgs && msgs.length > 0) {
+          chat.messages = msgs;
+        }
+      }
+
+      if (totalChatCount === 0) totalChatCount = chats.length;
     } finally {
       ws.close();
     }

--- a/frontend/packages/openmates-cli/src/ws.ts
+++ b/frontend/packages/openmates-cli/src/ws.ts
@@ -160,6 +160,49 @@ export class OpenMatesWsClient {
   }
 
   /**
+   * Collect all frames until `terminatorType` arrives (or timeout).
+   * Returns every frame received before the terminator, in order.
+   * Used by ensureSynced to consume the full phased-sync event stream.
+   */
+  collectMessages(terminatorType: string, timeoutMs = 90_000): Promise<WsEnvelope[]> {
+    return new Promise<WsEnvelope[]>((resolve, reject) => {
+      const collected: WsEnvelope[] = [];
+
+      const onMessage = (rawData: RawData) => {
+        try {
+          const parsed = JSON.parse(rawData.toString()) as WsEnvelope;
+          if (parsed.type === terminatorType) {
+            cleanup();
+            resolve(collected);
+            return;
+          }
+          collected.push(parsed);
+        } catch {
+          // ignore non-JSON frames
+        }
+      };
+
+      const onError = (error: Error) => { cleanup(); reject(error); };
+      const onClose = () => { cleanup(); resolve(collected); };
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error(`Timeout waiting for '${terminatorType}'`));
+      }, timeoutMs);
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        this.socket.off("message", onMessage);
+        this.socket.off("error", onError);
+        this.socket.off("close", onClose);
+      };
+
+      this.socket.on("message", onMessage);
+      this.socket.on("error", onError);
+      this.socket.on("close", onClose);
+    });
+  }
+
+  /**
    * Collect the AI response for a sent message.
    *
    * The server has two delivery paths:

--- a/frontend/packages/ui/src/components/embeds/MarkdownContent.svelte
+++ b/frontend/packages/ui/src/components/embeds/MarkdownContent.svelte
@@ -1,0 +1,142 @@
+<!--
+  frontend/packages/ui/src/components/embeds/MarkdownContent.svelte
+
+  Shared component for rendering markdown text in embed fullscreens.
+  Uses markdown-it (linkify + typographer) + DOMPurify for XSS safety.
+  All links open in a new tab with noopener noreferrer.
+
+  Usage:
+    <MarkdownContent content={event.description} />
+
+  See docs/architecture/messaging/embeds.md
+-->
+
+<script lang="ts">
+  interface Props {
+    /** Markdown or plain text to render */
+    content: string;
+    /** Additional CSS class for the container */
+    class?: string;
+  }
+
+  let { content, class: extraClass = '' }: Props = $props();
+
+  let rendered = $state('');
+
+  async function renderMarkdown(text: string): Promise<void> {
+    if (!text) { rendered = ''; return; }
+
+    try {
+      const [MarkdownItModule, DOMPurifyModule] = await Promise.all([
+        import('markdown-it'),
+        import('dompurify'),
+      ]);
+      const MarkdownIt = MarkdownItModule.default;
+      const DOMPurify = DOMPurifyModule.default;
+
+      const md = new MarkdownIt({
+        html: false,   // never trust raw HTML from external sources
+        linkify: true, // auto-linkify bare URLs
+        typographer: true,
+        breaks: true,  // treat single newlines as <br>
+      });
+
+      const rawHtml = md.render(text);
+
+      DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+        if (node.tagName === 'A') {
+          node.setAttribute('target', '_blank');
+          node.setAttribute('rel', 'noopener noreferrer');
+        }
+      });
+
+      rendered = DOMPurify.sanitize(rawHtml, {
+        ALLOWED_TAGS: [
+          'p', 'br', 'hr',
+          'strong', 'b', 'em', 'i', 'u', 's', 'del',
+          'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+          'ul', 'ol', 'li',
+          'blockquote', 'code', 'pre',
+          'a',
+        ],
+        ALLOWED_ATTR: ['href', 'title', 'target', 'rel'],
+        ALLOWED_URI_REGEXP: /^(?:(?:f|ht)tps?|mailto|tel|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i,
+      });
+
+      DOMPurify.removeHook('afterSanitizeAttributes');
+    } catch {
+      // Safe fallback: escape HTML and preserve line breaks
+      rendered = text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\n/g, '<br>');
+    }
+  }
+
+  $effect(() => {
+    renderMarkdown(content);
+  });
+</script>
+
+<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+<div class="markdown-content {extraClass}">{@html rendered}</div>
+
+<style>
+  .markdown-content {
+    font-size: 0.875rem;
+    color: var(--color-font-primary);
+    line-height: 1.65;
+    word-break: break-word;
+  }
+
+  .markdown-content :global(p) {
+    margin: 0 0 0.6em;
+  }
+
+  .markdown-content :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .markdown-content :global(a) {
+    color: var(--color-primary, #e63c2e);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .markdown-content :global(a:hover) {
+    opacity: 0.8;
+  }
+
+  .markdown-content :global(ul),
+  .markdown-content :global(ol) {
+    margin: 0.4em 0;
+    padding-left: 1.4em;
+  }
+
+  .markdown-content :global(li) {
+    margin-bottom: 0.2em;
+  }
+
+  .markdown-content :global(code) {
+    font-size: 0.8125em;
+    background: var(--color-grey-15);
+    border-radius: 3px;
+    padding: 1px 4px;
+  }
+
+  .markdown-content :global(blockquote) {
+    margin: 0.5em 0;
+    padding-left: 0.8em;
+    border-left: 3px solid var(--color-grey-30);
+    color: var(--color-font-secondary);
+  }
+
+  .markdown-content :global(h1),
+  .markdown-content :global(h2),
+  .markdown-content :global(h3) {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    margin: 0.6em 0 0.3em;
+  }
+</style>

--- a/frontend/packages/ui/src/components/embeds/UnifiedEmbedFullscreen.svelte
+++ b/frontend/packages/ui/src/components/embeds/UnifiedEmbedFullscreen.svelte
@@ -1194,6 +1194,11 @@
     scrollbar-width: thin;
     scrollbar-color: rgba(128, 128, 128, 0.2) transparent;
     transition: scrollbar-color var(--duration-normal) var(--easing-default);
+    /* Allow users to select and copy text in fullscreen embed content */
+    user-select: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
   }
 
   .content-area:hover {

--- a/frontend/packages/ui/src/components/embeds/events/EventEmbedFullscreen.svelte
+++ b/frontend/packages/ui/src/components/embeds/events/EventEmbedFullscreen.svelte
@@ -13,6 +13,7 @@
 <script lang="ts">
   import EntryWithMapTemplate from '../EntryWithMapTemplate.svelte';
   import EmbedHeaderCtaButton from '../EmbedHeaderCtaButton.svelte';
+  import MarkdownContent from '../MarkdownContent.svelte';
   import { text } from '@repo/ui';
   import { proxyImage, MAX_WIDTH_HEADER_IMAGE } from '../../../utils/imageProxy';
   import type { EmbedFullscreenRawData } from '../../../types/embedFullscreen';
@@ -445,7 +446,7 @@
     {#if event.description}
       <div class="event-section">
         <div class="section-label">About</div>
-        <div class="event-description">{event.description}</div>
+        <MarkdownContent content={event.description} />
       </div>
     {/if}
   {/snippet}
@@ -547,13 +548,6 @@
     font-size: 0.875rem;
   }
 
-  .event-description {
-    font-size: 0.875rem;
-    color: var(--color-font-primary);
-    line-height: 1.65;
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
 
   /* Today / Tomorrow label — larger than the regular date value */
   .date-relative {

--- a/frontend/packages/ui/src/components/embeds/nutrition/NutritionRecipeEmbedFullscreen.svelte
+++ b/frontend/packages/ui/src/components/embeds/nutrition/NutritionRecipeEmbedFullscreen.svelte
@@ -11,6 +11,7 @@
 <script lang="ts">
   import UnifiedEmbedFullscreen from '../UnifiedEmbedFullscreen.svelte';
   import EmbedHeaderCtaButton from '../EmbedHeaderCtaButton.svelte';
+  import MarkdownContent from '../MarkdownContent.svelte';
   import { text } from '@repo/ui';
   import { proxyImage } from '../../../utils/imageProxy';
 
@@ -139,7 +140,9 @@
         <h2 class="title">{title}</h2>
 
         {#if recipe.description}
-          <p class="description">{recipe.description}</p>
+          <div class="description">
+            <MarkdownContent content={recipe.description} />
+          </div>
         {/if}
 
         <!-- Meta row: time, difficulty, servings, rating -->
@@ -294,6 +297,8 @@
 
   .description {
     margin: 0;
+  }
+  .description :global(.markdown-content) {
     font-size: var(--font-size-small);
     color: var(--color-font-secondary);
     line-height: 1.5;

--- a/frontend/packages/ui/src/components/embeds/travel/TravelStayEmbedFullscreen.svelte
+++ b/frontend/packages/ui/src/components/embeds/travel/TravelStayEmbedFullscreen.svelte
@@ -18,6 +18,7 @@
 <script lang="ts">
   import EntryWithMapTemplate from '../EntryWithMapTemplate.svelte';
   import EmbedHeaderCtaButton from '../EmbedHeaderCtaButton.svelte';
+  import MarkdownContent from '../MarkdownContent.svelte';
   import { proxyImage, MAX_WIDTH_HEADER_IMAGE } from '../../../utils/imageProxy';
   import { text } from '@repo/ui';
   import type { EmbedFullscreenRawData } from '../../../types/embedFullscreen';
@@ -248,7 +249,9 @@
 
     <!-- Description -->
     {#if stay.description}
-      <div class="description-section"><p>{stay.description}</p></div>
+      <div class="description-section">
+        <MarkdownContent content={stay.description} />
+      </div>
     {/if}
 
     <!-- Amenities -->
@@ -403,13 +406,15 @@
     padding: var(--spacing-6);
     background: var(--color-grey-10, rgba(0, 0, 0, 0.03));
     border-radius: var(--radius-4);
-  }
-  .description-section p {
     font-size: var(--font-size-xs);
     color: var(--color-font-secondary);
     line-height: 1.5;
-    margin: 0;
-    word-break: break-word;
+  }
+  /* Override MarkdownContent defaults to match description-section visual style */
+  .description-section :global(.markdown-content) {
+    font-size: var(--font-size-xs);
+    color: var(--color-font-secondary);
+    line-height: 1.5;
   }
 
   .amenities-grid { display: flex; flex-wrap: wrap; gap: var(--spacing-3); }

--- a/frontend/packages/ui/src/services/handlersMessageHighlights.ts
+++ b/frontend/packages/ui/src/services/handlersMessageHighlights.ts
@@ -32,14 +32,21 @@ async function decryptInto(
   updated_at?: number,
   key_version?: number | null,
 ): Promise<MessageHighlight | null> {
-  const chatKey = chatKeyManager.getKeySync(chat_id)
-    ?? (await chatKeyManager.getKey(chat_id));
-  if (!chatKey) {
+  // KEYS-04: use withKey() so decrypt is buffered until the key is resident in
+  // memory — getKeySync()/getKey() returns null during async IDB unwrap on
+  // secondary devices, silently dropping highlights received during phased sync.
+  let chatKey: Uint8Array | null = null;
+  try {
+    await chatKeyManager.withKey(chat_id, "decrypt-highlight", async (key) => {
+      chatKey = key;
+    });
+  } catch {
     console.warn(
       `[handlersMessageHighlights] no chat key for chat ${chat_id} — dropping highlight ${id}`,
     );
     return null;
   }
+  if (!chatKey) return null;
   const plain = await decryptHighlightPayload(encrypted_payload, chatKey, {
     chatId: chat_id,
     messageId: message_id,


### PR DESCRIPTION
## Summary

This PR collects four bug fixes merged to `dev` since v0.9.0-alpha. The biggest user-facing items are a broken CLI pair login for passkey accounts and a content-decryption failure on secondary devices. Two smaller fixes improve embed text rendering and tighten the CI prerelease version bump.

## Bug Fixes

### CLI pair login — passkey users blocked + chat list timeout
- Removed an obsolete `encrypted_key`/`salt` DB lookup in `auth_pair.py` that blocked passkey users (those accounts never had those fields).
- Replaced the broken `phase3 + waitForMessage('phase_3_last_100_chats')` sync handshake in the CLI client with a new `collectMessages()` helper (`ws.ts`) that buffers all frames until a terminator frame arrives, fixing the chat-list timeout on slow connections.

### Encryption key race in message-highlight decrypt handler
- `handlersMessageHighlights.ts` was calling `getKeySync() ?? getKey()` — the sync path returned a stale/null key on secondary devices while the async key was still loading.
- Fixed by wrapping the handler with `withKey()` so decryption always waits for the resolved key, preventing the `content decryption failed` error (issue ed206641).

### Text selectability and markdown rendering in embed fullscreens
- Added `user-select: text` to `.content-area` in `UnifiedEmbedFullscreen.svelte` so users can select and copy text across all embed types.
- Extracted a shared `MarkdownContent.svelte` component (markdown-it + DOMPurify, link-safe) used by event, travel-stay, and nutrition-recipe fullscreens so descriptions render rich markdown and URLs are clickable.

## CI / Build

### CLI prerelease version bump
- `npm version prerelease` was reading from the repo's `package.json` (already at `0.9.0-alpha.X`) instead of the last published npm version, causing the prerelease counter to reset.
- Fixed to resolve the base version from the published npm registry before bumping.