### PR TITLE
fix(ci): stable npm publish for CLI — handle prerelease versions on main

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -53,6 +53,15 @@ jobs:
           fi
           npm version prerelease --preid alpha --no-git-tag-version
 
+      - name: Bump to stable version (main only)
+        if: github.ref == 'refs/heads/main'
+        working-directory: frontend/packages/openmates-cli
+        run: |
+          # Strip prerelease suffix so e.g. 0.9.0-alpha.5 → 0.9.0 before stable publish.
+          CURRENT=$(node -p "require('./package.json').version")
+          BASE="${CURRENT%%-*}"
+          npm version "$BASE" --no-git-tag-version --allow-same-version
+
       - name: Publish to npm (stable)
         if: github.ref == 'refs/heads/main'
         working-directory: frontend/packages/openmates-cli

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -57,10 +57,20 @@ jobs:
         if: github.ref == 'refs/heads/main'
         working-directory: frontend/packages/openmates-cli
         run: |
-          # Strip prerelease suffix so e.g. 0.9.0-alpha.5 → 0.9.0 before stable publish.
+          # Strip prerelease suffix (e.g. 0.9.0-alpha.5 → 0.9.0).
+          # If that base version is already published as stable, publish the next patch instead
+          # so repeated merges to main increment: 0.9.0 → 0.9.1 → 0.9.2 etc.
           CURRENT=$(node -p "require('./package.json').version")
           BASE="${CURRENT%%-*}"
-          npm version "$BASE" --no-git-tag-version --allow-same-version
+          LATEST=$(npm view openmates version 2>/dev/null || echo "0.0.0")
+          TARGET=$(node -e "
+            const parse = v => v.split('.').map(Number);
+            const [a, b] = [parse('$BASE'), parse('$LATEST')];
+            const ahead = a[0]-b[0] || a[1]-b[1] || a[2]-b[2];
+            if (ahead > 0) { console.log('$BASE'); }
+            else { b[2]++; console.log(b.join('.')); }
+          ")
+          npm version "\$TARGET" --no-git-tag-version --allow-same-version
 
       - name: Publish to npm (stable)
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

Fixes two related failures in the `Publish CLI` workflow that surfaced when the PR #379 merged `dev` into `main` while `package.json` still held a prerelease version (`0.9.0-alpha.X`). Both issues are in `.github/workflows/publish-cli.yml`.

## CI / Build

### Strip prerelease suffix before stable publish
`npm publish` without `--tag` is rejected by npm when the version string contains a prerelease identifier. Added a "Bump to stable version" step on the `main` branch that strips the suffix (e.g. `0.9.0-alpha.5` → `0.9.0`) before publishing.

### Auto-increment patch on repeated merges to main
If the stripped base version already exists on npm (e.g. a second merge to `main` while dev is still producing `0.9.0-alpha.X`), the step now compares against the current `latest` tag and bumps patch instead of colliding. Repeated merges produce `0.9.0` → `0.9.1` → `0.9.2` automatically.