### PR TITLE
fix(ci): fix $TARGET not expanding in stable npm publish step

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -58,19 +58,18 @@ jobs:
         working-directory: frontend/packages/openmates-cli
         run: |
           # Strip prerelease suffix (e.g. 0.9.0-alpha.5 → 0.9.0).
-          # If that base version is already published as stable, publish the next patch instead
-          # so repeated merges to main increment: 0.9.0 → 0.9.1 → 0.9.2 etc.
+          # If that base is already the published stable, bump patch instead so
+          # repeated merges to main produce 0.9.0 → 0.9.1 → 0.9.2 etc.
           CURRENT=$(node -p "require('./package.json').version")
           BASE="${CURRENT%%-*}"
           LATEST=$(npm view openmates version 2>/dev/null || echo "0.0.0")
-          TARGET=$(node -e "
-            const parse = v => v.split('.').map(Number);
-            const [a, b] = [parse('$BASE'), parse('$LATEST')];
-            const ahead = a[0]-b[0] || a[1]-b[1] || a[2]-b[2];
-            if (ahead > 0) { console.log('$BASE'); }
-            else { b[2]++; console.log(b.join('.')); }
-          ")
-          npm version "\$TARGET" --no-git-tag-version --allow-same-version
+          HIGHEST=$(printf '%s\n' "$BASE" "$LATEST" | sort -V | tail -1)
+          if [ "$BASE" != "$LATEST" ] && [ "$HIGHEST" = "$BASE" ]; then
+            npm version "$BASE" --no-git-tag-version --allow-same-version
+          else
+            npm version "$LATEST" --no-git-tag-version --allow-same-version
+            npm version patch --no-git-tag-version
+          fi
 
       - name: Publish to npm (stable)
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

One-commit follow-up to PR #382. The `\$TARGET` variable in the "Bump to stable version" step was backslash-escaped, so bash passed the literal string `$TARGET` to `npm version` instead of the computed value, causing `npm error Invalid version: $TARGET`.

## CI / Build

- Replaced the fragile inline `node -e` script (which required bash variables interpolated into a JS string inside a double-quoted shell string) with a clean bash-only approach using `sort -V` for semver comparison. Same logic: if the stripped base version (`0.9.0`) is newer than the current npm latest, use it directly; otherwise take the npm latest and bump patch.