### PR TITLE
fix: require credits to complete signup cleanup

### DIFF
--- a/backend/core/api/app/tasks/email_tasks/incomplete_signup_deletion_task.py
+++ b/backend/core/api/app/tasks/email_tasks/incomplete_signup_deletion_task.py
@@ -151,27 +151,30 @@ async def _get_stage_deliveries(task: BaseServiceTask, user_id: str) -> dict[str
     return {row.get("stage"): row for row in rows if row.get("stage")}
 
 
-async def _has_usage_or_invoice(task: BaseServiceTask, user_id: str) -> bool:
+async def _has_completed_credit_source(task: BaseServiceTask, user_id: str) -> bool:
     user_id_hash = hashlib.sha256(user_id.encode()).hexdigest()
-
-    usage = await task.directus_service.get_items(
-        "usage",
-        params={"filter": {"user_id_hash": {"_eq": user_id_hash}}, "fields": "id", "limit": 1},
-        admin_required=True,
-    )
-    if usage:
-        return True
 
     invoices = await task.directus_service.get_items(
         "invoices",
         params={
-            "filter": {"user_id_hash": {"_eq": user_id_hash}},
+            "filter": {
+                "user_id_hash": {"_eq": user_id_hash},
+                "status": {"_eq": "completed"},
+            },
             "fields": "id",
             "limit": 1,
         },
         admin_required=True,
     )
-    return bool(invoices)
+    if invoices:
+        return True
+
+    redeemed_gift_cards = await task.directus_service.get_items(
+        "redeemed_gift_cards",
+        params={"filter": {"user_id_hash": {"_eq": user_id_hash}}, "fields": "id", "limit": 1},
+        admin_required=True,
+    )
+    return bool(redeemed_gift_cards)
 
 
 async def _mark_signup_completed(task: BaseServiceTask, user_id: str, reason: str) -> None:
@@ -373,7 +376,7 @@ async def _async_process_incomplete_signup_deletions(
             users = await task.directus_service.get_items(
                 "directus_users",
                 params={
-                    "fields": "id,status,is_admin,last_opened,signup_completed,signup_started_at,last_online_timestamp,last_access,account_id,language,darkmode,vault_key_id,encrypted_username",
+                    "fields": "id,status,is_admin,signup_completed,signup_started_at,last_online_timestamp,last_access,account_id,language,darkmode,vault_key_id,encrypted_username",
                     "filter": {
                         "_and": [
                             {"status": {"_eq": "active"}},
@@ -405,16 +408,9 @@ async def _async_process_incomplete_signup_deletions(
                     stats["skipped_not_due"] += 1
                     continue
 
-                last_opened = user.get("last_opened") or ""
-                if not last_opened.startswith("/signup/"):
+                if await _has_completed_credit_source(task, user_id):
                     if not dry_run:
-                        await _mark_signup_completed(task, user_id, "last_opened_not_signup")
-                    stats["skipped_safety_completed"] += 1
-                    continue
-
-                if await _has_usage_or_invoice(task, user_id):
-                    if not dry_run:
-                        await _mark_signup_completed(task, user_id, "usage_or_invoice")
+                        await _mark_signup_completed(task, user_id, "completed_credit_source")
                     stats["skipped_safety_completed"] += 1
                     continue
 

--- a/backend/scripts/process_incomplete_signup_deletions.py
+++ b/backend/scripts/process_incomplete_signup_deletions.py
@@ -71,7 +71,7 @@ def _format_summary(result: dict, *, dry_run: bool) -> str:
         if skipped_not_due:
             lines.append(f"- {skipped_not_due} not due yet")
         if skipped_safety_completed:
-            lines.append(f"- {skipped_safety_completed} looked completed or had account activity")
+            lines.append(f"- {skipped_safety_completed} purchased credits or redeemed a gift card")
         if skipped_missing_email:
             lines.append(f"- {skipped_missing_email} had no decryptable email address")
 

--- a/backend/tests/test_security_regressions.py
+++ b/backend/tests/test_security_regressions.py
@@ -2,6 +2,7 @@
 #
 # Focused regression tests for merge-blocking security fixes.
 
+import hashlib
 import sys
 import types
 from types import SimpleNamespace
@@ -169,3 +170,34 @@ async def test_incomplete_signup_deletion_requires_account_contact_email():
     assert email is None
     assert username == ""
     task.encryption_service.decrypt_with_user_key.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_incomplete_signup_completion_requires_invoice_or_gift_card():
+    from backend.core.api.app.tasks.email_tasks.incomplete_signup_deletion_task import _has_completed_credit_source
+
+    user_id = "user-1"
+    user_id_hash = hashlib.sha256(user_id.encode()).hexdigest()
+    task = SimpleNamespace(directus_service=AsyncMock())
+    task.directus_service.get_items = AsyncMock(side_effect=[[], []])
+
+    assert await _has_completed_credit_source(task, user_id) is False
+
+    invoice_call, gift_card_call = task.directus_service.get_items.call_args_list
+    assert invoice_call.args[0] == "invoices"
+    assert invoice_call.kwargs["params"]["filter"] == {
+        "user_id_hash": {"_eq": user_id_hash},
+        "status": {"_eq": "completed"},
+    }
+    assert gift_card_call.args[0] == "redeemed_gift_cards"
+    assert gift_card_call.kwargs["params"]["filter"] == {"user_id_hash": {"_eq": user_id_hash}}
+
+
+@pytest.mark.asyncio
+async def test_incomplete_signup_completion_accepts_redeemed_gift_card():
+    from backend.core.api.app.tasks.email_tasks.incomplete_signup_deletion_task import _has_completed_credit_source
+
+    task = SimpleNamespace(directus_service=AsyncMock())
+    task.directus_service.get_items = AsyncMock(side_effect=[[], [{"id": "redemption-1"}]])
+
+    assert await _has_completed_credit_source(task, "user-1") is True


### PR DESCRIPTION
## Summary

Aligns the incomplete-signup deletion sweep with the OpenMates product rule that signup is only complete after a completed credit purchase or gift-card redemption. This prevents stale navigation state from incorrectly excluding abandoned accounts from reminder emails.

## Bug Fixes

- Treat completed invoices and redeemed gift cards as the only completion signals for the incomplete-signup deletion sweep.
- Stop using `last_opened` and generic usage rows as safety-completion signals for this cleanup flow.
- Update the manual deletion preview summary to describe the new credit-based skip condition.

## Other Changes

- Add regression coverage for the credit-source completion rule.

## Verification

- Lint passed via `sessions.py prepare-deploy` and `sessions.py deploy`.
- Python syntax verification passed for changed files.
- Focused pytest could not be completed in the available local/container environments due missing backend async test support/dependencies; deploy recorded this test-gate skip.