### PR TITLE
fix: count invoice records for signup cleanup

### DIFF
--- a/backend/core/api/app/tasks/email_tasks/incomplete_signup_deletion_task.py
+++ b/backend/core/api/app/tasks/email_tasks/incomplete_signup_deletion_task.py
@@ -157,10 +157,7 @@ async def _has_completed_credit_source(task: BaseServiceTask, user_id: str) -> b
     invoices = await task.directus_service.get_items(
         "invoices",
         params={
-            "filter": {
-                "user_id_hash": {"_eq": user_id_hash},
-                "status": {"_eq": "completed"},
-            },
+            "filter": {"user_id_hash": {"_eq": user_id_hash}},
             "fields": "id",
             "limit": 1,
         },

--- a/backend/tests/test_security_regressions.py
+++ b/backend/tests/test_security_regressions.py
@@ -185,10 +185,7 @@ async def test_incomplete_signup_completion_requires_invoice_or_gift_card():
 
     invoice_call, gift_card_call = task.directus_service.get_items.call_args_list
     assert invoice_call.args[0] == "invoices"
-    assert invoice_call.kwargs["params"]["filter"] == {
-        "user_id_hash": {"_eq": user_id_hash},
-        "status": {"_eq": "completed"},
-    }
+    assert invoice_call.kwargs["params"]["filter"] == {"user_id_hash": {"_eq": user_id_hash}}
     assert gift_card_call.args[0] == "redeemed_gift_cards"
     assert gift_card_call.kwargs["params"]["filter"] == {"user_id_hash": {"_eq": user_id_hash}}
 


### PR DESCRIPTION
## Summary

Fixes the follow-up invoice check in the incomplete-signup cleanup sweep. The previous merged cleanup rule filtered invoices by a `status=completed` field, but normal OpenMates credit-purchase invoice records are already created after successful payment and do not use that status filter.

## Bug Fixes

- Treat any invoice row for the user hash as evidence of a completed credit purchase.
- Stop triggering Directus permission errors from filtering invoices by the non-applicable `status` field.
- Keep the gift-card redemption check unchanged.

## Verification

- Lint passed via `sessions.py prepare-deploy` and `sessions.py deploy`.
- Python syntax verification passed for changed files.
- Related signup E2E specs were not run because they are broad end-to-end flows for this backend query correction.