### PR TITLE
Stabilize chat warmup and saved embed prompts

### DIFF
--- a/backend/core/api/app/services/email/variable_processor.py
+++ b/backend/core/api/app/services/email/variable_processor.py
@@ -3,8 +3,6 @@ from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
 
-logger.setLevel(logging.DEBUG)
-
 def process_template_variables(context: Dict[Any, Any]) -> Dict[Any, Any]:
     """
     Process template variables and set appropriate defaults
@@ -57,15 +55,15 @@ def process_template_variables(context: Dict[Any, Any]) -> Dict[Any, Any]:
     if 'refund_deep_link_url' in processed_context and processed_context.get('refund_deep_link_url'):
         # Use the deep link URL as refund_link
         processed_context['refund_link'] = processed_context['refund_deep_link_url']
-        logger.debug(f"Using refund_deep_link_url as refund_link: {processed_context['refund_link'][:50]}...")
+        logger.debug("Using refund_deep_link_url as refund_link")
     elif 'refund_link' not in processed_context or not processed_context.get('refund_link'):
         # Fallback to mailto link only if deep link is not available and refund_link is not set
         processed_context['refund_link'] = f"mailto:{support_email}?subject=Refund%20Request"
-        logger.debug(f"Using default mailto refund_link: {processed_context['refund_link']}")
+        logger.debug("Using default mailto refund_link")
         
     if 'mailto_link_report_email' not in processed_context or not processed_context['mailto_link_report_email']:
         processed_context['mailto_link_report_email'] = f"mailto:{support_email}?subject=Suspicious%20Email%20Report"
-        logger.debug(f"Using default mailto_link_report_email: {processed_context['mailto_link_report_email']}")
+        logger.debug("Using default mailto_link_report_email")
     
     # Set block list URL for users to submit their email to be blocked
     # This replaces the mailto link in "did_not_request_email" translation
@@ -126,9 +124,9 @@ def process_template_variables(context: Dict[Any, Any]) -> Dict[Any, Any]:
                 from urllib.parse import quote
                 encoded_email = quote(default_email)
                 processed_context['block_list_url'] = f"{base_url}#email={encoded_email}"
-                logger.debug(f"No email found in context, using default email for blocklist URL: {default_email}")
+                logger.debug("No email found in context, using preview blocklist URL")
             
-            logger.debug(f"Set block_list_url={processed_context['block_list_url']}")
+            logger.debug("Set block_list_url")
         except Exception as e:
             # If we can't determine the URL, use a fallback
             processed_context['block_list_url'] = "https://openmates.org/block-email"

--- a/backend/core/api/app/services/translations.py
+++ b/backend/core/api/app/services/translations.py
@@ -14,6 +14,24 @@ class TranslationService:
     _class_yaml_cache: Dict[str, Dict[str, Any]] = {}  # Cache for loaded YAML files (shared across languages)
     
     def __init__(self):
+        # Generated locale JSON is the runtime format. YAML remains the source of truth
+        # for authors, but parsing every YAML source costs several seconds in workers.
+        self.locales_dir = os.getenv("TRANSLATIONS_DIR")
+        if not self.locales_dir:
+            current_file = os.path.abspath(__file__)
+            if current_file.startswith('/app/'):
+                self.locales_dir = "/app/frontend/packages/ui/src/i18n/locales"
+            else:
+                project_root = os.path.dirname(
+                    os.path.dirname(
+                        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(current_file))))
+                    )
+                )
+                self.locales_dir = os.path.join(
+                    project_root,
+                    "frontend", "packages", "ui", "src", "i18n", "locales"
+                )
+
         # Try to get translations directory from environment variable first
         # Default to YAML sources directory (source of truth)
         self.sources_dir = os.getenv("TRANSLATIONS_SOURCES_DIR")
@@ -42,7 +60,11 @@ class TranslationService:
                     "frontend", "packages", "ui", "src", "i18n", "sources"
                 )
         
-        logger.info(f"Translation service initialized with YAML sources directory: {self.sources_dir}")
+        logger.info(
+            "Translation service initialized with locales directory: %s, YAML sources directory: %s",
+            self.locales_dir,
+            self.sources_dir,
+        )
     
     def get_translations(self, lang: str = "en", variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
@@ -66,6 +88,12 @@ class TranslationService:
         processed_translations = self._replace_variables_in_translations(raw_translations, variables)
         
         return processed_translations
+
+    def warm_cache(self, *languages: str) -> None:
+        """Load runtime translations into this process' shared cache."""
+        languages_to_load = languages or ("en",)
+        for lang in languages_to_load:
+            self.get_translations(lang=lang)
     
     def _load_all_yaml_files(self) -> Dict[str, Dict[str, Any]]:
         """
@@ -274,6 +302,12 @@ class TranslationService:
         # Check if translations are already cached in class-level cache
         if lang in TranslationService._class_translations_cache:
             return TranslationService._class_translations_cache[lang]
+
+        generated_translations = self._load_generated_locale_json(lang)
+        if generated_translations is not None:
+            TranslationService._class_translations_cache[lang] = generated_translations
+            logger.info(f"Loaded generated translations for language '{lang}' into shared cache")
+            return generated_translations
         
         try:
             # Load all YAML files
@@ -302,6 +336,49 @@ class TranslationService:
                 # If English file is missing, return empty dict
                 logger.error("English translation file not found")
                 return {}
+
+    def _load_generated_locale_json(self, lang: str) -> Optional[Dict[str, Any]]:
+        """
+        Load generated locale JSON for runtime use.
+
+        YAML files are authoring sources and can be expensive to parse in Celery
+        child processes. Generated JSON keeps runtime startup fast while preserving
+        YAML fallback for development environments that have not built translations.
+        """
+        if not self.locales_dir:
+            return None
+
+        locale_path = os.path.join(self.locales_dir, f"{lang}.json")
+        if not os.path.exists(locale_path):
+            logger.warning(
+                "Generated locale JSON not found for language '%s' at %s; falling back to YAML sources",
+                lang,
+                locale_path,
+            )
+            return None
+
+        try:
+            with open(locale_path, 'r', encoding='utf-8') as f:
+                translations = json.load(f)
+        except Exception as e:
+            logger.error(
+                "Failed to load generated locale JSON for language '%s' at %s: %s; falling back to YAML sources",
+                lang,
+                locale_path,
+                str(e),
+            )
+            return None
+
+        if not isinstance(translations, dict):
+            logger.error(
+                "Generated locale JSON for language '%s' at %s is %s, expected dict; falling back to YAML sources",
+                lang,
+                locale_path,
+                type(translations).__name__,
+            )
+            return None
+
+        return translations
     
     def _replace_variables_in_translations(self, translations: Dict[str, Any], variables: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/backend/core/api/app/tasks/celery_config.py
+++ b/backend/core/api/app/tasks/celery_config.py
@@ -4,6 +4,7 @@ import os
 import logging
 import sys
 import importlib
+import time
 from typing import Optional
 from urllib.parse import quote
 import asyncio
@@ -16,6 +17,7 @@ from backend.core.api.app.utils.config_manager import ConfigManager
 from backend.core.api.app.utils.request_context import set_request_id
 from backend.core.api.app.services.invoiceninja.invoiceninja import InvoiceNinjaService
 from backend.core.api.app.services.pdf.invoice import InvoiceTemplateService
+from backend.core.api.app.services.translations import TranslationService
 from backend.core.api.app.utils.secrets_manager import SecretsManager
 from backend.core.api.app.services.cache import CacheService as _CacheService
 
@@ -598,6 +600,20 @@ async def prewarm_ai_services():
             logger.info("[PERF] SecretsManager closed after AI pre-warming")
 
 
+def warm_translation_cache() -> None:
+    """Pre-load translations in each Celery child process before tasks run."""
+    start_time = time.perf_counter()
+    try:
+        translation_service = TranslationService()
+        translation_service.warm_cache("en")
+    except Exception as e:
+        logger.error("[PERF] Translation cache warmup failed: %s", e, exc_info=True)
+        return
+
+    elapsed = time.perf_counter() - start_time
+    logger.info("[PERF] Translation cache warmup completed in %.3fs", elapsed)
+
+
 # ===========================================================================
 # CELERY SIGNAL HANDLERS - Task lifecycle monitoring for reliability
 # ===========================================================================
@@ -893,6 +909,8 @@ def init_worker_process(*args, **kwargs):
     # Only initialize services that are needed at worker startup
     # For app workers, services are initialized per-task as needed
     asyncio.run(initialize_services())
+
+    warm_translation_cache()
 
     # OPE-342: Build the in-process SkillRegistry for this worker process.
     # Workers used to HTTP-POST to app-{id}:8000 containers; now they import

--- a/backend/core/api/main.py
+++ b/backend/core/api/main.py
@@ -494,9 +494,7 @@ async def lifespan(app: FastAPI):
     # This ensures translations are ready before any requests come in
     logger.info("Pre-loading translations into cache...")
     try:
-        # Pre-load English translations (default language)
-        # This will load all YAML files and convert them to JSON structure, storing in class-level cache
-        app.state.translation_service.get_translations(lang="en")
+        app.state.translation_service.warm_cache("en")
         logger.info("Translations pre-loaded successfully into shared cache.")
     except Exception as e:
         logger.error(f"Failed to pre-load translations during startup: {e}", exc_info=True)

--- a/backend/tests/test_celery_config.py
+++ b/backend/tests/test_celery_config.py
@@ -1,0 +1,22 @@
+# backend/tests/test_celery_config.py
+#
+# Tests Celery worker boot helpers that are too small for integration tests.
+# Worker process startup preloads process-local caches before any queued task can
+# run, which prevents first-request latency spikes after worker restarts. These
+# tests keep that boot-time contract explicit without starting a real worker.
+
+
+def test_warm_translation_cache_preloads_english(monkeypatch):
+    from backend.core.api.app.tasks import celery_config
+
+    calls: list[str] = []
+
+    class FakeTranslationService:
+        def warm_cache(self, *languages: str) -> None:
+            calls.extend(languages)
+
+    monkeypatch.setattr(celery_config, "TranslationService", FakeTranslationService)
+
+    celery_config.warm_translation_cache()
+
+    assert calls == ["en"]

--- a/backend/tests/test_translation_service.py
+++ b/backend/tests/test_translation_service.py
@@ -1,0 +1,86 @@
+# backend/tests/test_translation_service.py
+#
+# Tests runtime translation loading behavior.
+# Translation YAML remains the authoring source, but backend services should use
+# generated locale JSON when available to avoid slow YAML parsing in Celery
+# worker request paths. These tests keep that performance-sensitive preference
+# explicit while preserving YAML fallback coverage.
+
+from backend.core.api.app.services.translations import TranslationService
+
+
+def _clear_translation_caches() -> None:
+    TranslationService._class_translations_cache.clear()
+    TranslationService._class_yaml_cache.clear()
+
+
+def test_translation_service_prefers_generated_locale_json(tmp_path, monkeypatch):
+    locales_dir = tmp_path / "locales"
+    sources_dir = tmp_path / "sources"
+    locales_dir.mkdir()
+    sources_dir.mkdir()
+
+    (locales_dir / "en.json").write_text(
+        '{"app_skills": {"web": {"search": {"text": "Fast JSON description"}}}}',
+        encoding="utf-8",
+    )
+    (sources_dir / "app_skills.yml").write_text(
+        "web.search:\n  en: Slow YAML description\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("TRANSLATIONS_DIR", str(locales_dir))
+    monkeypatch.setenv("TRANSLATIONS_SOURCES_DIR", str(sources_dir))
+    _clear_translation_caches()
+
+    service = TranslationService()
+
+    assert service.get_nested_translation("app_skills.web.search") == "Fast JSON description"
+    assert TranslationService._class_yaml_cache == {}
+
+
+def test_translation_service_warm_cache_loads_generated_locale_json(tmp_path, monkeypatch):
+    locales_dir = tmp_path / "locales"
+    sources_dir = tmp_path / "sources"
+    locales_dir.mkdir()
+    sources_dir.mkdir()
+
+    (locales_dir / "en.json").write_text(
+        '{"common": {"ok": {"text": "OK"}}}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("TRANSLATIONS_DIR", str(locales_dir))
+    monkeypatch.setenv("TRANSLATIONS_SOURCES_DIR", str(sources_dir))
+    _clear_translation_caches()
+
+    service = TranslationService()
+    service.warm_cache("en")
+
+    assert TranslationService._class_translations_cache["en"]["common"]["ok"]["text"] == "OK"
+    assert TranslationService._class_yaml_cache == {}
+
+
+def test_translation_service_falls_back_to_yaml_when_generated_json_missing(tmp_path, monkeypatch):
+    locales_dir = tmp_path / "locales"
+    sources_dir = tmp_path / "sources"
+    locales_dir.mkdir()
+    sources_dir.mkdir()
+
+    (sources_dir / "app_skills.yml").write_text(
+        "web.search:\n  en: YAML fallback description\n",
+        encoding="utf-8",
+    )
+    (sources_dir / "languages.json").write_text("{}", encoding="utf-8")
+
+    # The service expects languages.json next to the real source tree, not the
+    # temporary one, so use the repo default for language discovery and only
+    # override the YAML sources/locales directories.
+    monkeypatch.setenv("TRANSLATIONS_DIR", str(locales_dir))
+    monkeypatch.setenv("TRANSLATIONS_SOURCES_DIR", str(sources_dir))
+    _clear_translation_caches()
+
+    service = TranslationService()
+
+    assert service.get_nested_translation("app_skills.web.search") == "YAML fallback description"
+    assert "app_skills" in TranslationService._class_yaml_cache

--- a/frontend/apps/web_app/tests/chat-flow.spec.ts
+++ b/frontend/apps/web_app/tests/chat-flow.spec.ts
@@ -600,6 +600,7 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 	const sendButton = page.locator('[data-action="send-message"]');
 	await expect(sendButton).toBeVisible({ timeout: 15000 });
 	await expect(sendButton).toBeEnabled({ timeout: 5000 });
+	const messageSendStartedAt = Date.now();
 	await sendButton.click();
 	logChatCheckpoint('Sent message: "Capital of Germany?"');
 	await takeStepScreenshot(page, '03-message-sent');
@@ -623,6 +624,10 @@ test('logs in and sends a chat message', async ({ page }: { page: any }) => {
 	logChatCheckpoint('Waiting for assistant response...');
 	const assistantResponse = page.getByTestId('message-assistant');
 	await expect(assistantResponse.last()).toContainText('Berlin', { timeout: 45000 });
+	const messageResponseMs = Date.now() - messageSendStartedAt;
+	console.log(`[PERF] chat_flow_message_response_ms=${messageResponseMs}`);
+	logChatCheckpoint(`Message response latency: ${messageResponseMs}ms`, { messageResponseMs });
+	expect(messageResponseMs, 'Chat response should avoid the previous 9s translation cold-start delay').toBeLessThan(30000);
 	await takeStepScreenshot(page, '04-response-received');
 	logChatCheckpoint('Confirmed "Berlin" in assistant response.');
 

--- a/frontend/packages/ui/src/services/savedEmbedMemoryService.ts
+++ b/frontend/packages/ui/src/services/savedEmbedMemoryService.ts
@@ -443,6 +443,7 @@ export async function saveEmbedMemory(config: SavedEmbedConfig): Promise<void> {
 
 export function promptToSaveEmbedMemory(config: SavedEmbedConfig): void {
   if (!get(authStore).isAuthenticated) return;
+  if (isEmbedMemorySaved(config)) return;
 
   let notificationId = '';
   notificationId = notificationStore.addNotificationWithOptions('info', {


### PR DESCRIPTION
## Summary
This PR stabilizes the current dev branch before merging to main by reducing first-request translation latency, suppressing already-saved embed prompts, and preventing sensitive newsletter debug output. It also adds Playwright timing output for chat responses so deployment checks can track the impact of translation warmup changes.

## Bug Fixes
- Warm generated runtime translations during API and Celery worker startup so first chat requests do not pay the cold translation parsing cost.
- Hide the saved embed memory prompt when an authenticated user opens an embed that already matches a saved memory item.
- Mask recipient-specific email template values in debug logs and respect the configured logging level for email variable processing.

## Other Changes
- Add chat-flow Playwright timing output for assistant response latency to support post-deploy performance verification.
- Add backend coverage for translation service warmup and Celery startup translation loading.