### PR TITLE
Fix inline embed refs and async skill continuations

### DIFF
--- a/backend/apps/ai/processing/main_processor.py
+++ b/backend/apps/ai/processing/main_processor.py
@@ -951,7 +951,8 @@ async def handle_main_processing(
     secrets_manager: Optional[SecretsManager] = None,
     cache_service: Optional[CacheService] = None,
     always_include_skills: Optional[List[str]] = None,  # Skills to ALWAYS include regardless of preprocessing
-    user_overrides: Optional[UserOverrides] = None  # User overrides from @mention syntax (for skip-permission logic)
+    user_overrides: Optional[UserOverrides] = None,  # User overrides from @mention syntax (for skip-permission logic)
+    skill_config_dict: Optional[dict[str, Any]] = None,
 ) -> AsyncIterator[Union[str, MistralUsage, GoogleUsageMetadata, AnthropicUsageMetadata, OpenAIUsageMetadata]]:
     """
     Handles the main processing of an AI skill request after preprocessing.
@@ -3673,6 +3674,7 @@ async def handle_main_processing(
                                 cache_service=cache_service,
                                 async_task_id=async_task_id,
                                 request_data=request_data,
+                                skill_config_dict=skill_config_dict,
                                 app_id=app_id,
                                 skill_id=skill_id,
                                 tool_name=tool_name,

--- a/backend/apps/ai/tasks/ask_skill_task.py
+++ b/backend/apps/ai/tasks/ask_skill_task.py
@@ -1593,6 +1593,7 @@ async def _async_process_ai_skill_ask_task(
         thinking_content: list = []  # Accumulated thinking chunks from the stream (for debug cache only)
 
         try:
+            skill_config_dict = skill_config.model_dump(mode="json") if hasattr(skill_config, "model_dump") else {}
             aggregated_final_response, revoked_in_consumer, soft_limited_in_consumer, thinking_content, main_processor_debug_metadata = await _consume_main_processing_stream(  # type: ignore[assignment]
                 task_id=task_id,
                 request_data=request_data,
@@ -1610,7 +1611,8 @@ async def _async_process_ai_skill_ask_task(
                 # This is a safety net for critical skills like web-search that should be available
                 # for follow-up queries even when preprocessing fails to detect the user's intent.
                 always_include_skills=skill_config.always_include_skills if skill_config else None,
-                user_overrides=user_overrides  # Pass user overrides for skip-permission logic on mentioned keys
+                user_overrides=user_overrides,  # Pass user overrides for skip-permission logic on mentioned keys
+                skill_config_dict=skill_config_dict,
             )
             logger.info(f"[Task ID: {task_id}] Main processing stream consumed.")
 

--- a/backend/apps/ai/tasks/async_skill_continuation.py
+++ b/backend/apps/ai/tasks/async_skill_continuation.py
@@ -11,7 +11,10 @@ import logging
 import asyncio
 import json
 import time
+import os
 from typing import Any, Optional
+
+import yaml
 
 try:
     from toon_format import encode as toon_encode
@@ -19,7 +22,7 @@ except ImportError:  # pragma: no cover - test environments may not install opti
     def toon_encode(value: Any) -> str:
         return json.dumps(value, ensure_ascii=False)
 
-from backend.apps.ai.skills.ask_skill import AskSkillDefaultConfig, AskSkillRequest
+from backend.apps.ai.skills.ask_skill import AskSkillRequest
 from backend.core.api.app.schemas.chat import AIHistoryMessage
 
 logger = logging.getLogger(__name__)
@@ -45,6 +48,7 @@ async def cache_async_skill_continuation_context(
     cache_service: Any,
     async_task_id: str,
     request_data: AskSkillRequest,
+    skill_config_dict: Optional[dict[str, Any]] = None,
     app_id: str,
     skill_id: str,
     tool_name: str,
@@ -57,6 +61,7 @@ async def cache_async_skill_continuation_context(
 
     context = {
         "request_data": request_data.model_dump(mode="json"),
+        "skill_config_dict": skill_config_dict or {},
         "app_id": app_id,
         "skill_id": skill_id,
         "tool_name": tool_name,
@@ -111,6 +116,14 @@ async def dispatch_async_skill_continuation(
         return None
 
     original_request = AskSkillRequest(**request_payload)
+    skill_config_payload = context.get("skill_config_dict")
+    if not isinstance(skill_config_payload, dict):
+        logger.warning("Async skill continuation context has invalid skill_config_dict for task %s", async_task_id)
+        skill_config_payload = {}
+    if not skill_config_payload.get("default_llms"):
+        logger.warning("Async skill continuation context missing ask skill config for task %s; loading app.yml fallback", async_task_id)
+        skill_config_payload = _load_ask_skill_config_from_app_yml()
+
     continuation_history = [
         AIHistoryMessage(**(message.model_dump(mode="json") if hasattr(message, "model_dump") else message))
         for message in original_request.message_history
@@ -151,7 +164,7 @@ async def dispatch_async_skill_continuation(
         name="apps.ai.tasks.skill_ask",
         kwargs={
             "request_data_dict": continuation_request.model_dump(mode="json"),
-            "skill_config_dict": AskSkillDefaultConfig().model_dump(mode="json"),
+            "skill_config_dict": skill_config_payload,
         },
         queue="app_ai",
     )
@@ -192,6 +205,24 @@ def _get_celery_app() -> Any:
 
         celery_app = configured_app
     return celery_app
+
+
+def _load_ask_skill_config_from_app_yml() -> dict[str, Any]:
+    """Load the ask skill config needed to run continuation tasks safely."""
+    app_yml_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "app.yml")
+    try:
+        with open(app_yml_path, "r", encoding="utf-8") as file:
+            app_config = yaml.safe_load(file) or {}
+    except Exception as exc:
+        logger.error("Failed to load ask skill config from %s: %s", app_yml_path, exc, exc_info=True)
+        return {}
+
+    for skill in app_config.get("skills", []):
+        if skill.get("id") == "ask":
+            default_config = skill.get("skill_config")
+            return default_config if isinstance(default_config, dict) else {}
+    logger.error("Ask skill config not found in %s", app_yml_path)
+    return {}
 
 
 def _build_completed_tool_result_message(

--- a/backend/apps/ai/tasks/stream_consumer.py
+++ b/backend/apps/ai/tasks/stream_consumer.py
@@ -1954,6 +1954,7 @@ async def _consume_main_processing_stream(
     secrets_manager: Optional[SecretsManager] = None,
     always_include_skills: Optional[List[str]] = None,  # Skills to ALWAYS include regardless of preprocessing
     user_overrides: Optional[UserOverrides] = None,  # User overrides from @mention syntax
+    skill_config_dict: Optional[Dict[str, Any]] = None,
 ) -> tuple[str, bool, bool, list, Optional[Dict[str, Any]]]:
     """
     Consumes the async stream from handle_main_processing, aggregates the response,
@@ -2073,7 +2074,8 @@ async def _consume_main_processing_stream(
         secrets_manager=secrets_manager, # Pass SecretsManager
         cache_service=cache_service, # Pass CacheService for skill status publishing
         always_include_skills=always_include_skills,  # Pass always-include skills from config
-        user_overrides=user_overrides  # Pass user overrides for skip-permission logic
+        user_overrides=user_overrides,  # Pass user overrides for skip-permission logic
+        skill_config_dict=skill_config_dict,
     )
 
     stream_chunk_count = 0

--- a/backend/apps/social_media/app.yml
+++ b/backend/apps/social_media/app.yml
@@ -72,7 +72,7 @@ embed_types:
     fullscreen_component: social_media/SocialMediaSearchEmbedFullscreen.svelte
     child_preview_component: social_media/SocialMediaPostEmbedPreview.svelte
     child_fullscreen_component: social_media/SocialMediaPostEmbedFullscreen.svelte
-    icon: socialmedia
+    icon: search
     gradient_var: "--color-app-socialmedia"
     i18n_namespace: embeds.social_media.search
     content_fields:
@@ -189,7 +189,7 @@ skills:
   - id: search
     name_translation_key: app_skills.social_media.search
     description_translation_key: app_skills.social_media.search.description
-    icon_image: socialmedia.svg
+    icon_image: search.svg
     preprocessor_hint: >
       Search supported social platforms for recent public posts around a topic.
       Use this for topic monitoring and broad discovery across pages/profiles,

--- a/backend/tests/test_async_skill_continuation.py
+++ b/backend/tests/test_async_skill_continuation.py
@@ -89,6 +89,22 @@ def _request():
     )
 
 
+def _skill_config_dict():
+    return {
+        "enable_auto_model_selection": False,
+        "default_llms": {
+            "preprocessing_model": "mistral/small",
+            "main_processing_simple": "google/gemini-flash",
+            "main_processing_complex": "google/gemini-pro",
+        },
+        "preprocessing_thresholds": {
+            "harmful_content_score": 7,
+            "misuse_risk_score": 7,
+        },
+        "always_include_skills": ["web-search"],
+    }
+
+
 @pytest.mark.asyncio
 async def test_cache_async_skill_continuation_context_stores_original_request(async_skill_continuation):
     cache = _FakeCache()
@@ -97,6 +113,7 @@ async def test_cache_async_skill_continuation_context_stores_original_request(as
         cache_service=cache,
         async_task_id="async-task-1",
         request_data=_request(),
+        skill_config_dict=_skill_config_dict(),
         app_id="social_media",
         skill_id="search",
         tool_name="social_media-search",
@@ -106,6 +123,7 @@ async def test_cache_async_skill_continuation_context_stores_original_request(as
     key = async_skill_continuation.async_skill_continuation_key("async-task-1")
     assert cache.values[key]["ttl"] == async_skill_continuation.ASYNC_SKILL_CONTINUATION_TTL_SECONDS
     assert cache.values[key]["value"]["request_data"]["chat_id"] == "chat-1"
+    assert cache.values[key]["value"]["skill_config_dict"]["default_llms"]["preprocessing_model"] == "mistral/small"
     assert cache.values[key]["value"]["tool_name"] == "social_media-search"
 
 
@@ -118,6 +136,7 @@ async def test_dispatch_async_skill_continuation_sends_normal_ask_task(monkeypat
         cache_service=cache,
         async_task_id="async-task-1",
         request_data=_request(),
+        skill_config_dict=_skill_config_dict(),
         app_id="social_media",
         skill_id="search",
         tool_name="social_media-search",
@@ -135,10 +154,13 @@ async def test_dispatch_async_skill_continuation_sends_normal_ask_task(monkeypat
     assert fake_celery_app.sent[0]["name"] == "apps.ai.tasks.skill_ask"
     assert fake_celery_app.sent[0]["queue"] == "app_ai"
     request_payload = fake_celery_app.sent[0]["kwargs"]["request_data_dict"]
+    skill_config_payload = fake_celery_app.sent[0]["kwargs"]["skill_config_dict"]
     assert request_payload["chat_id"] == "chat-1"
     assert request_payload["message_history"][-1]["role"] == "system"
     assert "Completed tool result" in request_payload["message_history"][-1]["content"]
     assert "A useful post" in request_payload["message_history"][-1]["content"]
+    assert skill_config_payload["default_llms"]["preprocessing_model"] == "mistral/small"
+    assert skill_config_payload["always_include_skills"] == ["web-search"]
     assert cache.deleted == [async_skill_continuation.async_skill_continuation_key("async-task-1")]
 
 
@@ -151,6 +173,7 @@ async def test_dispatch_async_skill_continuation_caches_inline_wait_result(monke
         cache_service=cache,
         async_task_id="async-task-1",
         request_data=_request(),
+        skill_config_dict=_skill_config_dict(),
         app_id="social_media",
         skill_id="search",
         tool_name="social_media-search",

--- a/frontend/packages/ui/src/components/embeds/EmbedInlineLink.svelte
+++ b/frontend/packages/ui/src/components/embeds/EmbedInlineLink.svelte
@@ -59,6 +59,12 @@
 
   let { embedRef, embedId = null, displayText, appId = null, focusLineStart = null, focusLineEnd = null, highlightQuoteText = null, focusSheetRange = null }: Props = $props();
 
+  type RepairState = 'idle' | 'repairing' | 'resolved' | 'broken';
+  const DIRECT_EMBED_REF_RE = /-[0-9a-f]{6}$/i;
+
+  let repairState = $state<RepairState>('idle');
+  let isDirectRepairableRef = $derived(DIRECT_EMBED_REF_RE.test(embedRef));
+
   // Reactively resolve the effective appId.
   //
   // $embedRefIndexVersion is a Svelte auto-subscription to the embedRefIndexVersion
@@ -80,15 +86,17 @@
     // Whenever registerEmbedRef() increments this store, Svelte re-runs this
     // derived and picks up the newly available appId — no full re-parse needed.
     void $embedRefIndexVersion;
-    return appId ?? embedStore.resolveAppIdByRef(embedRef);
+    return appId ?? embedStore.resolveAppIdByRef(embedRef) ?? (focusLineStart != null && repairState !== 'broken' ? 'code' : null);
   });
 
   // Badge gradient (circular icon background) — unchanged from original design.
-  // Falls back to neutral grey when appId is unknown.
+  // Grey is reserved for refs we already tried and failed to repair.
   let gradientStyle = $derived(
     effectiveAppId
       ? `background: var(--color-app-${effectiveAppId});`
-      : 'background: var(--color-grey-30);',
+      : repairState === 'broken'
+        ? 'background: var(--color-grey-30);'
+        : 'background: var(--color-button-primary);',
   );
 
   // Solid text colour — switches between START (dark) and END (light) colours
@@ -111,6 +119,35 @@
 
   let effectiveDisplayText = $derived(resolveEmbedDisplayText(displayText, embedRef));
 
+  $effect(() => {
+    void $embedRefIndexVersion;
+
+    if (embedId || embedStore.resolveByRef(embedRef)) {
+      repairState = 'resolved';
+      return;
+    }
+
+    if (!isDirectRepairableRef) {
+      repairState = 'idle';
+      return;
+    }
+
+    let cancelled = false;
+    repairState = 'repairing';
+
+    embedStore.resolveByRefDeep(embedRef).then((resolvedEmbedId) => {
+      if (cancelled) return;
+      repairState = resolvedEmbedId ? 'resolved' : 'broken';
+    }).catch((error) => {
+      console.warn(`[EmbedInlineLink] Failed to repair embed_ref "${embedRef}"`, error);
+      if (!cancelled) repairState = 'broken';
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
   /**
    * Open embed fullscreen on click.
    * Resolves embed_ref → embed_id at click time (lazy resolution handles the case
@@ -127,10 +164,11 @@
     e.preventDefault();
     e.stopPropagation();
 
-    // Resolve embed_ref to embed_id (lazy, in case it arrived after first render)
-    const resolvedEmbedId = embedId || embedStore.resolveByRef(embedRef);
+    // Resolve embed_ref to embed_id. The deep path repairs cold direct refs after reload.
+    const resolvedEmbedId = embedId || await embedStore.resolveByRefDeep(embedRef);
 
     if (!resolvedEmbedId) {
+      repairState = isDirectRepairableRef ? 'broken' : repairState;
       console.warn(
         `[EmbedInlineLink] Cannot open fullscreen: embed_ref "${embedRef}" not yet resolved`,
       );
@@ -166,13 +204,13 @@
 </script>
 
 <!-- Inline badge + link, rendered as a <span> so it flows within text -->
-<span class="embed-inline-link" role="link" tabindex="0" onclick={handleClick} onkeydown={(e) => { if (e.key === 'Enter') handleClick(e as unknown as MouseEvent); }}>
+<span class="embed-inline-link" class:embed-inline-link--broken={repairState === 'broken'} role="link" tabindex="0" onclick={handleClick} onkeydown={(e) => { if (e.key === 'Enter') handleClick(e as unknown as MouseEvent); }}>
   <!-- Small circular app-icon badge -->
   <span class="embed-inline-badge" style={gradientStyle} aria-hidden="true">
     <span class="icon_rounded {effectiveAppId || ''}"></span>
   </span>
   <!-- Solid-colour display text — colour adapts to light/dark mode via CSS -->
-  <span class="embed-inline-text" class:has-app-color={!!effectiveAppId} style={textColorVarsStyle}>{effectiveDisplayText}</span>
+  <span class="embed-inline-text" class:has-app-color={!!effectiveAppId} class:broken={repairState === 'broken'} style={textColorVarsStyle}>{effectiveDisplayText}</span>
 </span>
 
 <style>
@@ -196,6 +234,10 @@
 
   .embed-inline-link:hover {
     opacity: 0.8;
+  }
+
+  .embed-inline-link--broken {
+    cursor: not-allowed;
   }
 
   /* 20 px circular gradient badge — mirrors .app-icon-circle from BasicInfosBar.svelte
@@ -269,6 +311,10 @@
     font-size: inherit;
     font-weight: 500;
     line-height: inherit;
+    color: var(--color-button-primary);
+  }
+
+  .embed-inline-text.broken {
     color: var(--color-grey-60);
   }
 
@@ -276,7 +322,15 @@
     color: var(--_link-color-light);
   }
 
+  .embed-inline-text.has-app-color.broken {
+    color: var(--color-grey-60);
+  }
+
   :global([data-theme="dark"]) .embed-inline-text.has-app-color {
     color: var(--_link-color-dark);
+  }
+
+  :global([data-theme="dark"]) .embed-inline-text.has-app-color.broken {
+    color: var(--color-grey-60);
   }
 </style>

--- a/frontend/packages/ui/src/components/embeds/social_media/SocialMediaSearchEmbedFullscreen.svelte
+++ b/frontend/packages/ui/src/components/embeds/social_media/SocialMediaSearchEmbedFullscreen.svelte
@@ -57,7 +57,7 @@
 <SearchResultsTemplate
   appId="social_media"
   skillId="search"
-  skillIconName="socialmedia"
+  skillIconName="search"
   embedHeaderTitle={query}
   embedHeaderSubtitle={viaProvider}
   {onClose}

--- a/frontend/packages/ui/src/components/embeds/social_media/SocialMediaSearchEmbedPreview.svelte
+++ b/frontend/packages/ui/src/components/embeds/social_media/SocialMediaSearchEmbedPreview.svelte
@@ -68,7 +68,7 @@
   {id}
   appId="social_media"
   skillId="search"
-  skillIconName="socialmedia"
+  skillIconName="search"
   status={localStatus}
   skillName="Search"
   {isMobile}

--- a/frontend/packages/ui/src/services/embedStore.ts
+++ b/frontend/packages/ui/src/services/embedStore.ts
@@ -55,6 +55,7 @@ interface EmbedRefEntry {
 const embedRefToIdIndex = new Map<string, EmbedRefEntry>();
 
 const MAX_CHILD_EMBEDS_TO_INDEX = 50;
+const DIRECT_EMBED_REF_ID_PREFIX_RE = /^[0-9a-f]{6}$/i;
 
 // Reactive version counter — incremented on every registerEmbedRef() call.
 // EmbedInlineLink.svelte subscribes to this Svelte store so it re-derives
@@ -251,6 +252,93 @@ export class EmbedStore {
       return foundParentEmbedId;
     }
     return null;
+  }
+
+  private extractDirectEmbedIdPrefix(embedRef: string): string | null {
+    const separatorIndex = embedRef.lastIndexOf("-");
+    if (separatorIndex === -1) return null;
+
+    const suffix = embedRef.slice(separatorIndex + 1);
+    return DIRECT_EMBED_REF_ID_PREFIX_RE.test(suffix) ? suffix.toLowerCase() : null;
+  }
+
+  private getEntryEmbedId(entry: EmbedStoreEntry): string | null {
+    if (entry.embed_id) return this.normalizeEmbedId(entry.embed_id);
+    return this.extractEmbedIdFromContentRef(entry.contentRef);
+  }
+
+  private collectDirectRefCandidatesFromEntries(
+    entries: EmbedStoreEntry[],
+    embedIdPrefix: string,
+  ): string[] {
+    const candidates = new Set<string>();
+    for (const entry of entries) {
+      if (entry.status === "error" || entry.status === "cancelled") continue;
+
+      const embedId = this.getEntryEmbedId(entry);
+      if (embedId?.toLowerCase().startsWith(embedIdPrefix)) {
+        candidates.add(embedId);
+      }
+    }
+    return Array.from(candidates);
+  }
+
+  private collectDirectRefCandidatesFromCache(embedIdPrefix: string): string[] {
+    return this.collectDirectRefCandidatesFromEntries(
+      Array.from(embedCache.values()),
+      embedIdPrefix,
+    );
+  }
+
+  private async collectDirectRefCandidatesFromIndexedDb(
+    embedIdPrefix: string,
+  ): Promise<string[]> {
+    try {
+      const transaction = await chatDB.getTransaction(
+        [EMBEDS_STORE_NAME],
+        "readonly",
+      );
+      const store = transaction.objectStore(EMBEDS_STORE_NAME);
+
+      const allEntries = await new Promise<EmbedStoreEntry[]>(
+        (resolve, reject) => {
+          const request = store.getAll();
+          request.onsuccess = () => resolve(request.result || []);
+          request.onerror = () => reject(request.error);
+        },
+      );
+
+      return this.collectDirectRefCandidatesFromEntries(allEntries, embedIdPrefix);
+    } catch (error) {
+      console.debug(
+        "[EmbedStore] Failed to scan IndexedDB for direct embed_ref lookup:",
+        error,
+      );
+      return [];
+    }
+  }
+
+  private async extractRefFromResolvedEmbed(
+    embed: Record<string, unknown> | string | undefined,
+  ): Promise<{ embedRef: string | null; appId: string | null }> {
+    if (!embed) return { embedRef: null, appId: null };
+
+    let decodedSource: unknown = embed;
+    if (typeof embed === "object" && typeof embed.content === "string") {
+      decodedSource = await decodeToonContentLocal(embed.content);
+    } else if (typeof embed === "string") {
+      decodedSource = await decodeToonContentLocal(embed);
+    }
+
+    if (!decodedSource || typeof decodedSource !== "object") {
+      return { embedRef: null, appId: null };
+    }
+
+    const decoded = decodedSource as Record<string, unknown>;
+    return {
+      embedRef: typeof decoded.embed_ref === "string" ? decoded.embed_ref : null,
+      appId: typeof decoded.app_id === "string" ? decoded.app_id : null,
+    };
   }
 
   private async findParentEmbedIdInIndexedDb(
@@ -2598,6 +2686,47 @@ export class EmbedStore {
    */
   resolveByRef(embedRef: string): string | null {
     return embedRefToIdIndex.get(embedRef)?.embedId ?? null;
+  }
+
+  /**
+   * Resolve an embed_ref, repairing cold direct refs by verifying decrypted content.
+   *
+   * Direct embed refs are generated as `<slug>-<first6EmbedIdChars>`. After a
+   * reload the in-memory ref index is empty, but synced encrypted embed rows still
+   * contain the plaintext embed_id. We use the suffix only to find candidates, then
+   * decrypt and verify the embedded TOON still contains the exact requested ref.
+   */
+  async resolveByRefDeep(embedRef: string): Promise<string | null> {
+    const indexedEmbedId = this.resolveByRef(embedRef);
+    if (indexedEmbedId) return indexedEmbedId;
+
+    const embedIdPrefix = this.extractDirectEmbedIdPrefix(embedRef);
+    if (!embedIdPrefix) return null;
+
+    const candidates = new Set<string>(
+      this.collectDirectRefCandidatesFromCache(embedIdPrefix),
+    );
+    for (const embedId of await this.collectDirectRefCandidatesFromIndexedDb(
+      embedIdPrefix,
+    )) {
+      candidates.add(embedId);
+    }
+
+    for (const candidateEmbedId of Array.from(candidates)) {
+      const resolvedEmbed = await this.get(`embed:${candidateEmbedId}`);
+
+      const registeredEmbedId = this.resolveByRef(embedRef);
+      if (registeredEmbedId) return registeredEmbedId;
+
+      const { embedRef: verifiedRef, appId } =
+        await this.extractRefFromResolvedEmbed(resolvedEmbed);
+      if (verifiedRef === embedRef) {
+        this.registerEmbedRef(embedRef, candidateEmbedId, appId);
+        return candidateEmbedId;
+      }
+    }
+
+    return null;
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR fixes two regressions affecting embed-backed chat flows after reloads and async skill completions. Inline embed links can now be repaired from synced encrypted embed data on demand, and async skill continuations preserve the original ask skill configuration so completed results remain interpretable by the AI pipeline.

## Bug Fixes
- Repair direct inline embed references after reload by resolving UUID-prefix refs from synced embeds when the link is used.
- Keep repairable inline embed links visually active until a repair attempt confirms that the embed cannot be resolved.
- Preserve the original ask skill configuration across async skill continuations so social media search completions are processed with the correct pipeline context.
- Use the search skill icon for social media search embeds to keep preview and fullscreen rendering consistent.

## Other Changes
- Add backend coverage for async skill continuation config preservation.