### PR TITLE
Prepare v0.14 package publishing and settings updates

### DIFF
--- a/.agents/skills/create-release/SKILL.md
+++ b/.agents/skills/create-release/SKILL.md
@@ -18,7 +18,7 @@ argument-hint: "[tag]"
 
 ### Step 1 — Determine Version
 
-Current phase: **Alpha** (v0.x.x-alpha). Check the latest tag:
+Current phase: **Alpha**. Product UI shows short product lines such as `v0.14`; release tags and package/image artifacts use exact patch versions such as `v0.14.0`, `v0.14.1`, and `v0.14.2`. Check the latest tag:
 ```bash
 gh release list --limit 3
 ```
@@ -26,9 +26,9 @@ gh release list --limit 3
 Version bump decision:
 | Change type | Bump | Example |
 |-------------|------|---------|
-| New features | Minor | v0.13.0 → v0.14.0 |
-| Bug fixes only | Patch | v0.13.0 → v0.13.1 |
-| Breaking changes | Major | v0.13.0 → v1.0.0 |
+| New features | Minor product line | v0.13 → v0.14 |
+| Bug fixes / repeated main publishes | Patch artifact | v0.14.0 → v0.14.1 |
+| Breaking changes | Major | v0.14 → v1.0 |
 
 ### Step 2 — Write Release Notes
 

--- a/.agents/skills/new-task/SKILL.md
+++ b/.agents/skills/new-task/SKILL.md
@@ -32,7 +32,7 @@ Analyze the user's input and determine:
    - `UI`, `Backend`, `DevOps`, `testing`, `docs`, `marketing`, `payment`
    - `cronjob`, `user-feedback`, `SEO`
 6. **Project**: Suggest Web App or CLI based on content
-7. **Milestone**: Suggest v0.13.1 (stability/UI fixes) or v0.14.0 (features) based on scope
+7. **Milestone**: Suggest the current product line for ongoing work (for example `v0.14`) or the next minor product line for larger features (for example `v0.15`). Patch numbers such as `0.14.1` are artifact revisions, not user-facing milestones.
 8. **Spec size**: Decide `none`, `inline`, or `full` using `docs/contributing/guides/spec-driven-development.md`
 
 ### Step 2: Present the Suggested Task
@@ -47,7 +47,7 @@ Show the user what will be created:
 **Priority:** High (2)
 **Labels:** Bug, UI
 **Project:** Web App
-**Milestone:** v0.13.1
+**Milestone:** v0.14
 
 ### Description
 The create reminder UI is broken — [expanded description based on user input].

--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -18,7 +18,7 @@ argument-hint: "[tag]"
 
 ### Step 1 — Determine Version
 
-Current phase: **Alpha** (v0.x.x-alpha). Check the latest tag:
+Current phase: **Alpha**. Product UI shows short product lines such as `v0.14`; release tags and package/image artifacts use exact patch versions such as `v0.14.0`, `v0.14.1`, and `v0.14.2`. Check the latest tag:
 ```bash
 gh release list --limit 3
 ```
@@ -26,9 +26,9 @@ gh release list --limit 3
 Version bump decision:
 | Change type | Bump | Example |
 |-------------|------|---------|
-| New features | Minor | v0.13.0 → v0.14.0 |
-| Bug fixes only | Patch | v0.13.0 → v0.13.1 |
-| Breaking changes | Major | v0.13.0 → v1.0.0 |
+| New features | Minor product line | v0.13 → v0.14 |
+| Bug fixes / repeated main publishes | Patch artifact | v0.14.0 → v0.14.1 |
+| Breaking changes | Major | v0.14 → v1.0 |
 
 ### Step 2 — Write Release Notes
 

--- a/.claude/skills/new-task/SKILL.md
+++ b/.claude/skills/new-task/SKILL.md
@@ -32,7 +32,7 @@ Analyze the user's input and determine:
    - `UI`, `Backend`, `DevOps`, `testing`, `docs`, `marketing`, `payment`
    - `cronjob`, `user-feedback`, `SEO`
 6. **Project**: Suggest Web App or CLI based on content
-7. **Milestone**: Suggest v0.13.1 (stability/UI fixes) or v0.14.0 (features) based on scope
+7. **Milestone**: Suggest the current product line for ongoing work (for example `v0.14`) or the next minor product line for larger features (for example `v0.15`). Patch numbers such as `0.14.1` are artifact revisions, not user-facing milestones.
 8. **Spec size**: Decide `none`, `inline`, or `full` using `docs/contributing/guides/spec-driven-development.md`
 
 ### Step 2: Present the Suggested Task
@@ -47,7 +47,7 @@ Show the user what will be created:
 **Priority:** High (2)
 **Labels:** Bug, UI
 **Project:** Web App
-**Milestone:** v0.13.1
+**Milestone:** v0.14
 
 ### Description
 The create reminder UI is broken — [expanded description based on user input].

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,6 +1,6 @@
 # Publish openmates CLI to npm.
-# - main branch → always checks the configured stable release and publishes it
-#   to npm `latest` if the exact version is not already published
+# - main branch → publishes the next stable patch in the configured release line
+#   to npm `latest`
 # - dev branch → npm `alpha` tag when CLI/versioning files change
 #
 # Uses npm Trusted Publishing (OIDC) — no NPM_TOKEN secret needed.

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,6 +1,7 @@
-# Publish openmates CLI to npm when CLI code changes.
-# - main branch → npm `latest` tag (stable release)
-# - dev branch → npm `alpha` tag (prerelease)
+# Publish openmates CLI to npm.
+# - main branch → always checks the configured stable release and publishes it
+#   to npm `latest` if the exact version is not already published
+# - dev branch → npm `alpha` tag when CLI/versioning files change
 #
 # Uses npm Trusted Publishing (OIDC) — no NPM_TOKEN secret needed.
 # Configure at: npmjs.com → openmates → Settings → Trusted Publishing → Link GitHub repo.
@@ -9,15 +10,50 @@ name: Publish CLI
 on:
   push:
     branches: [main, dev]
-    paths:
-      - 'frontend/packages/openmates-cli/**'
-      - 'scripts/prepare_cli_publish_version.mjs'
-      - 'shared/config/product_version.json'
-      - '.github/workflows/publish-cli.yml'
   workflow_dispatch: {}
 
+concurrency:
+  group: publish-cli-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_publish: ${{ steps.filter.outputs.should_publish }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to publish
+        id: filter
+        shell: bash
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          before="${{ github.event.before }}"
+          after="${{ github.sha }}"
+          if [ -z "$before" ] || [[ "$before" =~ ^0+$ ]]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$before" "$after")"
+          if printf '%s\n' "$changed_files" | grep -E '^(frontend/packages/openmates-cli/|scripts/prepare_cli_publish_version\.mjs$|shared/config/product_version\.json$|\.github/workflows/publish-cli\.yml$)' >/dev/null; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-test:
+    needs: changes
+    if: needs.changes.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -50,8 +86,8 @@ jobs:
           retention-days: 1
 
   publish:
-    needs: build-test
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
+    needs: [changes, build-test]
+    if: needs.changes.outputs.should_publish == 'true' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -70,15 +106,30 @@ jobs:
           path: frontend/packages/openmates-cli/dist
 
       - name: Bump prerelease version (dev only)
+        id: dev-version
         if: github.ref == 'refs/heads/dev'
         run: node scripts/prepare_cli_publish_version.mjs --channel=dev
 
       - name: Bump to stable version (main only)
+        id: stable-version
         if: github.ref == 'refs/heads/main'
         run: node scripts/prepare_cli_publish_version.mjs --channel=main
 
-      - name: Publish to npm (stable)
+      - name: Check whether stable version is already published
+        id: stable-published
         if: github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          version="${{ steps.stable-version.outputs.version }}"
+          if npm view "openmates@$version" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "openmates@$version is already published; skipping npm publish."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm (stable)
+        if: github.ref == 'refs/heads/main' && steps.stable-published.outputs.published != 'true'
         working-directory: frontend/packages/openmates-cli
         run: npm publish --provenance --access public
 

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -1,6 +1,6 @@
 # Publish the OpenMates Python SDK to PyPI.
 # - main branch → next stable patch in the configured release line
-# - dev branch → PEP 440 alpha prerelease, e.g. 0.14.0a1
+# - dev branch → PEP 440 alpha prerelease for the next patch, e.g. 0.14.1a0
 #
 # Uses PyPI Trusted Publishing (OIDC) — no PYPI_API_TOKEN secret needed.
 # Configure at: PyPI → Account settings → Publishing → Add pending publisher.

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -1,5 +1,5 @@
-# Publish the OpenMates Python SDK to PyPI when package code changes.
-# - main branch → stable PyPI release
+# Publish the OpenMates Python SDK to PyPI.
+# - main branch → next stable patch in the configured release line
 # - dev branch → PEP 440 alpha prerelease, e.g. 0.14.0a1
 #
 # Uses PyPI Trusted Publishing (OIDC) — no PYPI_API_TOKEN secret needed.
@@ -9,16 +9,50 @@ name: Publish Python SDK
 on:
   push:
     branches: [main, dev]
-    paths:
-      - 'packages/openmates-python/**'
-      - 'scripts/prepare_python_publish_version.py'
-      - 'scripts/tests/test_prepare_python_publish_version.py'
-      - 'shared/config/product_version.json'
-      - '.github/workflows/publish-python-sdk.yml'
   workflow_dispatch: {}
 
+concurrency:
+  group: publish-python-sdk-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_publish: ${{ steps.filter.outputs.should_publish }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to publish
+        id: filter
+        shell: bash
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          before="${{ github.event.before }}"
+          after="${{ github.sha }}"
+          if [ -z "$before" ] || [[ "$before" =~ ^0+$ ]]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$before" "$after")"
+          if printf '%s\n' "$changed_files" | grep -E '^(packages/openmates-python/|scripts/prepare_python_publish_version\.py$|scripts/tests/test_prepare_python_publish_version\.py$|shared/config/product_version\.json$|\.github/workflows/publish-python-sdk\.yml$)' >/dev/null; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-test:
+    needs: changes
+    if: needs.changes.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,8 +77,8 @@ jobs:
         run: python -m build
 
   publish:
-    needs: build-test
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
+    needs: [changes, build-test]
+    if: needs.changes.outputs.should_publish == 'true' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish-selfhost-images.yml
+++ b/.github/workflows/publish-selfhost-images.yml
@@ -327,4 +327,6 @@ jobs:
             echo
             echo "Results: API=${API_RESULT}, docs-worker=${DOCS_RESULT}, other-images=${IMAGE_RESULT}."
           } > "$body_file"
-          gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body-file "$body_file"
+          if ! gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body-file "$body_file"; then
+            echo "::warning::Failed to comment on PR #${pr_number}; image publish result is unchanged."
+          fi

--- a/.github/workflows/publish-selfhost-images.yml
+++ b/.github/workflows/publish-selfhost-images.yml
@@ -11,6 +11,11 @@ on:
         description: Optional pull request number to comment when publishing completes
         required: false
         type: string
+      notification_test:
+        description: Send notifications without building images
+        required: false
+        default: false
+        type: boolean
   push:
     branches: [main]
     paths:
@@ -68,6 +73,7 @@ jobs:
           echo "build_timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
   build-api:
+    if: ${{ inputs.notification_test != true }}
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -109,6 +115,7 @@ jobs:
             org.opencontainers.image.version=${{ needs.prepare.outputs.image_tag }}
 
   build-docs-worker:
+    if: ${{ inputs.notification_test != true }}
     needs: [prepare, build-api]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -142,6 +149,7 @@ jobs:
             OPENMATES_IMAGE_TAG=${{ needs.prepare.outputs.image_tag }}
 
   build-image:
+    if: ${{ inputs.notification_test != true }}
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -215,21 +223,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Summarize and notify merged PR
+      - name: Summarize and notify
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_RESULT: ${{ needs.build-api.result }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DOCS_RESULT: ${{ needs.build-docs-worker.result }}
           IMAGE_RESULT: ${{ needs.build-image.result }}
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
           IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
+          NOTIFICATION_TEST: ${{ inputs.notification_test }}
           NOTIFY_PR: ${{ inputs.notify_pr }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           status="success"
-          if [ "$API_RESULT" != "success" ] || [ "$DOCS_RESULT" != "success" ] || [ "$IMAGE_RESULT" != "success" ]; then
+          if [ "$NOTIFICATION_TEST" = "true" ]; then
+            status="test"
+          elif [ "$API_RESULT" != "success" ] || [ "$DOCS_RESULT" != "success" ] || [ "$IMAGE_RESULT" != "success" ]; then
             status="failure"
           fi
+          export PUBLISH_STATUS="$status"
 
           {
             echo "### Self-host image publish ${status}"
@@ -243,6 +256,56 @@ jobs:
             echo "| Docs worker | ${DOCS_RESULT} |"
             echo "| Other images | ${IMAGE_RESULT} |"
           } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
+            python3 - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+
+          status = os.environ["PUBLISH_STATUS"]
+          color = {"success": 0x2ecc71, "failure": 0xe74c3c, "test": 0xf1c40f}.get(status, 0x95a5a6)
+          title = f"Self-host Docker image publish {status}"
+          if status == "test":
+              title = "Self-host Docker image publish notification test"
+
+          payload = {
+              "username": "OpenMates CI",
+              "embeds": [
+                  {
+                      "title": title,
+                      "url": os.environ["RUN_URL"],
+                      "color": color,
+                      "fields": [
+                          {"name": "Image tag", "value": f"`{os.environ['IMAGE_TAG']}`", "inline": True},
+                          {"name": "Ref", "value": f"`{os.environ['GITHUB_REF_NAME']}`", "inline": True},
+                          {"name": "Commit", "value": f"`{os.environ['GITHUB_SHA'][:7]}`", "inline": True},
+                          {"name": "API", "value": os.environ.get("API_RESULT") or "n/a", "inline": True},
+                          {"name": "Docs worker", "value": os.environ.get("DOCS_RESULT") or "n/a", "inline": True},
+                          {"name": "Other images", "value": os.environ.get("IMAGE_RESULT") or "n/a", "inline": True},
+                      ],
+                      "footer": {"text": "OpenMates GitHub Actions"},
+                  }
+              ],
+          }
+          data = json.dumps(payload).encode("utf-8")
+          request = urllib.request.Request(
+              os.environ["DISCORD_WEBHOOK_URL"],
+              data=data,
+              headers={"Content-Type": "application/json", "User-Agent": "OpenMates-GitHub-Actions"},
+              method="POST",
+          )
+          try:
+              with urllib.request.urlopen(request, timeout=10) as response:
+                  if response.status >= 300:
+                      print(f"::warning::Discord notification returned HTTP {response.status}")
+          except (urllib.error.URLError, TimeoutError) as exc:
+              print(f"::warning::Discord notification failed: {exc}")
+          PY
+          else
+            echo "Discord webhook secret DISCORD_WEBHOOK_URL is not configured; skipping Discord notification."
+          fi
 
           pr_number="$NOTIFY_PR"
           if [ -z "$pr_number" ] && [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${GITHUB_REF}" = "refs/heads/main" ]; then

--- a/docs/architecture/platforms/cli-package.md
+++ b/docs/architecture/platforms/cli-package.md
@@ -51,7 +51,7 @@ claims:
 
 # CLI Package
 
-> npm package (`openmates`, v0.14.0) providing both a CLI and a programmatic SDK for signup, pair-auth login, encrypted chat operations, app skill execution, settings management, model benchmarking, bank-transfer billing, and self-hosted server management.
+> npm package openmates, 0.14.x artifact line for product line v0.14, providing both a CLI and a programmatic SDK for signup, pair-auth login, encrypted chat operations, app skill execution, settings management, model benchmarking, bank-transfer billing, and self-hosted server management.
 
 ## Why This Exists
 

--- a/docs/contributing/guides/git-and-deployment.md
+++ b/docs/contributing/guides/git-and-deployment.md
@@ -325,7 +325,7 @@ Inspect the commits going into the PR and decide:
 - Any `feat:` commits → consider a new minor product line (e.g. `v0.14` → `v0.15`)
 - Major milestone reached → consult the user before bumping major or changing phase
 
-**Note:** Also update `shared/config/product_version.json` when bumping the minor product line. Keep `userFacing` aligned with the short product line, e.g. `v0.14`, while `cli.stableBase` / `python.stableBase` define the artifact line start, e.g. `0.14.0`. Stable artifacts publish as `0.14.N`; dev prereleases target the next stable patch as `0.14.N-alpha.M` for npm and `0.14.NaM` for PyPI. Keep `frontend/packages/ui/src/i18n/sources/signup/main.yml` → `version_title` aligned with `userFacing`, then regenerate locale JSON files (see `docs/contributing/guides/i18n.md`).
+**Note:** Also update `shared/config/product_version.json` when bumping the minor product line. Keep `userFacing` aligned with the short product line, e.g. `v0.14`, while `cli.stableBase` / `python.stableBase` define the artifact line start, e.g. `0.14.0`. Stable artifacts publish as `0.14.N`. Dev prereleases use the next unused patch slot as `0.14.N-alpha.0` for npm and `0.14.Na0` for PyPI; main then promotes the latest prerelease slot to stable when applicable. Keep `frontend/packages/ui/src/i18n/sources/signup/main.yml` → `version_title` aligned with `userFacing`, then regenerate locale JSON files (see `docs/contributing/guides/i18n.md`).
 
 ### Release Workflow
 

--- a/docs/contributing/guides/git-and-deployment.md
+++ b/docs/contributing/guides/git-and-deployment.md
@@ -287,7 +287,13 @@ Releases are always created as **drafts** targeting `main` and marked as **pre-r
 
 ### Versioning Guidelines
 
-OpenMates uses **semantic versioning** in the format `vMAJOR.MINOR.PATCH-phase`:
+OpenMates separates the **user-facing product line** from exact artifact versions:
+
+- Product UI and marketing copy show `vMAJOR.MINOR`, for example `v0.14`.
+- npm, PyPI, GHCR images, and GitHub release tags use exact SemVer/PEP 440 patch versions, for example `0.14.0`, `0.14.1`, or `v0.14.1`.
+- `shared/config/product_version.json` is the source of truth: `userFacing` stores the product line, while `cli.stableBase` and `python.stableBase` store the first patch in the artifact release line.
+
+Artifact releases use semantic versioning in the format `vMAJOR.MINOR.PATCH-phase`:
 
 | Phase  | Example        | When to use                                                                             |
 | ------ | -------------- | --------------------------------------------------------------------------------------- |
@@ -295,12 +301,12 @@ OpenMates uses **semantic versioning** in the format `vMAJOR.MINOR.PATCH-phase`:
 | Beta   | `v1.0.0-beta`  | Core features complete; usable for a wider audience; known bugs being fixed             |
 | Stable | `v1.0.0`       | Production-ready; all major user flows work reliably                                    |
 
-**Current phase:** Alpha — the app is currently at **v0.14.0** (user-facing version string). The next release tag should be `v0.15.0` (or a patch like `v0.14.1` for fix-only releases).
+**Current phase:** Alpha — the app currently shows **v0.14** as the user-facing product line. Stable artifacts in this line publish as `0.14.0`, then `0.14.1`, `0.14.2`, and so on. The next minor product line is `v0.15`.
 
 **How to bump the version:**
 
-- **Patch** (`v0.5.0-alpha` → `v0.5.1-alpha`): bug fixes only, no new features
-- **Minor** (`v0.5.x-alpha` → `v0.6.0-alpha`): new features added or significant changes
+- **Patch artifact** (`v0.14.0` → `v0.14.1`): additional stable publishes inside the same product line
+- **Minor product line** (`v0.14` → `v0.15`): new features added or significant changes
 - **Major / phase change** (`v0.x-alpha` → `v1.0.0-beta`): when core user flows are stable and the app is ready for a broader audience — **always confirm with the user before doing this**
 
 **How to determine the next version:**
@@ -315,11 +321,11 @@ git tag --sort=-v:refname | head -5
 
 Inspect the commits going into the PR and decide:
 
-- Mostly `fix:` commits → patch bump (e.g. `v0.4.0-alpha` → `v0.4.1-alpha`)
-- Any `feat:` commits → minor bump (e.g. `v0.4.1-alpha` → `v0.5.0-alpha`)
+- Mostly `fix:` commits → stay in the current product line; stable package/image workflows publish the next patch artifact automatically
+- Any `feat:` commits → consider a new minor product line (e.g. `v0.14` → `v0.15`)
 - Major milestone reached → consult the user before bumping major or changing phase
 
-**Note:** Also update `shared/config/product_version.json` when bumping the minor version. Keep the user-facing `userFacing` value aligned with the release tag, e.g. `v0.14.0`, while the CLI `prereleaseBase` controls npm prerelease versions like `0.14.0-alpha.N`. Keep `frontend/packages/ui/src/i18n/sources/signup/main.yml` → `version_title` aligned with `userFacing`, then regenerate locale JSON files (see `docs/contributing/guides/i18n.md`).
+**Note:** Also update `shared/config/product_version.json` when bumping the minor product line. Keep `userFacing` aligned with the short product line, e.g. `v0.14`, while `cli.stableBase` / `python.stableBase` define the artifact line start, e.g. `0.14.0`. `cli.prereleaseBase` controls npm prerelease versions like `0.14.0-alpha.N`, and `python.prereleaseBase` controls PyPI prereleases like `0.14.0aN`. Keep `frontend/packages/ui/src/i18n/sources/signup/main.yml` → `version_title` aligned with `userFacing`, then regenerate locale JSON files (see `docs/contributing/guides/i18n.md`).
 
 ### Release Workflow
 

--- a/docs/contributing/guides/git-and-deployment.md
+++ b/docs/contributing/guides/git-and-deployment.md
@@ -325,7 +325,7 @@ Inspect the commits going into the PR and decide:
 - Any `feat:` commits → consider a new minor product line (e.g. `v0.14` → `v0.15`)
 - Major milestone reached → consult the user before bumping major or changing phase
 
-**Note:** Also update `shared/config/product_version.json` when bumping the minor product line. Keep `userFacing` aligned with the short product line, e.g. `v0.14`, while `cli.stableBase` / `python.stableBase` define the artifact line start, e.g. `0.14.0`. `cli.prereleaseBase` controls npm prerelease versions like `0.14.0-alpha.N`, and `python.prereleaseBase` controls PyPI prereleases like `0.14.0aN`. Keep `frontend/packages/ui/src/i18n/sources/signup/main.yml` → `version_title` aligned with `userFacing`, then regenerate locale JSON files (see `docs/contributing/guides/i18n.md`).
+**Note:** Also update `shared/config/product_version.json` when bumping the minor product line. Keep `userFacing` aligned with the short product line, e.g. `v0.14`, while `cli.stableBase` / `python.stableBase` define the artifact line start, e.g. `0.14.0`. Stable artifacts publish as `0.14.N`; dev prereleases target the next stable patch as `0.14.N-alpha.M` for npm and `0.14.NaM` for PyPI. Keep `frontend/packages/ui/src/i18n/sources/signup/main.yml` → `version_title` aligned with `userFacing`, then regenerate locale JSON files (see `docs/contributing/guides/i18n.md`).
 
 ### Release Workflow
 

--- a/docs/contributing/guides/publish-python-sdk.md
+++ b/docs/contributing/guides/publish-python-sdk.md
@@ -33,8 +33,7 @@ key:
 {
   "python": {
     "stableBase": "0.14.0",
-    "prereleaseBase": "0.14.0a",
-    "prereleaseSeed": "0.14.0a0"
+    "prereleaseLabel": "a"
   }
 }
 ```
@@ -42,7 +41,7 @@ key:
 The checked-in `packages/openmates-python/pyproject.toml` version should match
 `python.stableBase`. The publish workflow rewrites that version in CI only:
 
-- `dev` publishes the next alpha prerelease, for example `0.14.0a0`, `0.14.0a1`, and so on.
+- `dev` publishes alpha prereleases for the next stable patch in the configured release line. For example, before `0.14.0` is stable it publishes `0.14.0a0`, `0.14.0a1`; after `0.14.0` is stable it publishes `0.14.1a0`, `0.14.1a1`.
 - `main` publishes the next stable patch in the configured release line: `0.14.0`, then `0.14.1`, `0.14.2`, and so on. It ignores unrelated future lines when choosing the next patch.
 
 Use alpha releases for dev testing:

--- a/docs/contributing/guides/publish-python-sdk.md
+++ b/docs/contributing/guides/publish-python-sdk.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last_verified: 2026-06-22
+last_verified: 2026-07-08
 ---
 
 # Publish the Python SDK
@@ -43,7 +43,7 @@ The checked-in `packages/openmates-python/pyproject.toml` version should match
 `python.stableBase`. The publish workflow rewrites that version in CI only:
 
 - `dev` publishes the next alpha prerelease, for example `0.14.0a0`, `0.14.0a1`, and so on.
-- `main` publishes `python.stableBase` if it is not already on PyPI; otherwise it patch-bumps from the latest stable PyPI version.
+- `main` publishes the next stable patch in the configured release line: `0.14.0`, then `0.14.1`, `0.14.2`, and so on. It ignores unrelated future lines when choosing the next patch.
 
 Use alpha releases for dev testing:
 
@@ -76,9 +76,9 @@ python3 scripts/prepare_python_publish_version.py --channel=main --dry-run
 
 ## Automated Publish Flow
 
-The `.github/workflows/publish-python-sdk.yml` workflow runs on pushes to `dev`
-or `main` when Python SDK package files, version config, or the publish workflow
-change. It also supports manual `workflow_dispatch` runs.
+The `.github/workflows/publish-python-sdk.yml` workflow runs on every `main`
+push so stable artifacts stay aligned with main, and on `dev` only when Python
+SDK package files, version config, tests, or the publish workflow change. It also supports manual `workflow_dispatch` runs.
 
 1. Merge SDK changes into `dev`.
 2. Wait for `Publish Python SDK` to pass and publish the alpha prerelease.

--- a/docs/contributing/guides/publish-python-sdk.md
+++ b/docs/contributing/guides/publish-python-sdk.md
@@ -41,8 +41,8 @@ key:
 The checked-in `packages/openmates-python/pyproject.toml` version should match
 `python.stableBase`. The publish workflow rewrites that version in CI only:
 
-- `dev` publishes alpha prereleases for the next stable patch in the configured release line. For example, before `0.14.0` is stable it publishes `0.14.0a0`, `0.14.0a1`; after `0.14.0` is stable it publishes `0.14.1a0`, `0.14.1a1`.
-- `main` publishes the next stable patch in the configured release line: `0.14.0`, then `0.14.1`, `0.14.2`, and so on. It ignores unrelated future lines when choosing the next patch.
+- `dev` publishes the next unused patch slot as an alpha prerelease. For example, before `0.14.0` is stable it publishes `0.14.0a0`; the next dev publish in the same line publishes `0.14.1a0`.
+- `main` publishes the stable version for the latest prerelease patch slot if one exists; otherwise it publishes the next unused stable patch. For example, after `0.14.1a0`, main publishes `0.14.1`.
 
 Use alpha releases for dev testing:
 

--- a/docs/user-guide/developers/sdk.md
+++ b/docs/user-guide/developers/sdk.md
@@ -27,6 +27,8 @@ Install the npm package:
 npm install openmates
 ```
 
+Package page: [openmates on npm](https://www.npmjs.com/package/openmates)
+
 ```ts
 import { OpenMates } from "openmates";
 
@@ -76,6 +78,8 @@ Install the Python package:
 ```bash
 pip install openmates
 ```
+
+Package page: [openmates on PyPI](https://pypi.org/project/openmates/)
 
 ```python
 from openmates import OpenMates

--- a/frontend/apps/web_app/scripts/audit-example-seo.js
+++ b/frontend/apps/web_app/scripts/audit-example-seo.js
@@ -15,6 +15,7 @@ import { pathToFileURL } from 'node:url';
 const PAGES_DIR = '.svelte-kit/output/prerendered/pages';
 const SITEMAP_SERVER_ENTRY = '.svelte-kit/output/server/entries/endpoints/sitemap.xml/_server.ts.js';
 const MIN_TRANSCRIPT_WORDS = 120;
+const ALLOWED_DOCS_SITEMAP_PATHS = new Set(['/docs/user-guide/developers/sdk']);
 
 function walkHtmlFiles(dir) {
 	const files = [];
@@ -143,8 +144,13 @@ async function auditSitemap(exampleFiles) {
 		}
 	}
 
-	if (sitemapXml.includes('<loc>https://openmates.org/docs')) {
-		errors.push('/docs URLs should stay excluded from sitemap until docs are SEO-ready');
+	const docsLocs = [...sitemapXml.matchAll(/<loc>https:\/\/openmates\.org(\/docs[^<]*)<\/loc>/g)].map(
+		(match) => match[1]
+	);
+	for (const docsPath of docsLocs) {
+		if (!ALLOWED_DOCS_SITEMAP_PATHS.has(docsPath)) {
+			errors.push(`${docsPath} should stay excluded from sitemap until docs are SEO-ready`);
+		}
 	}
 
 	return errors;

--- a/frontend/apps/web_app/src/routes/sitemap.xml/+server.ts
+++ b/frontend/apps/web_app/src/routes/sitemap.xml/+server.ts
@@ -10,8 +10,10 @@
 //     - Intro chat SEO pages (/intro/{slug})
 //     - Public event pages (/events/{slug})
 //
-//   Documentation pages are intentionally excluded for now. Add /docs back to
-//   the sitemap once the docs web UI and content are cleaned up for public SEO.
+//   Documentation pages are mostly excluded for now. Add /docs back to the
+//   sitemap once the docs web UI and content are cleaned up for public SEO.
+//   The SDK docs page is included because it is the canonical OpenMates-owned
+//   landing URL for the npm and PyPI packages.
 //
 //   Example chats are hardcoded in the frontend — no backend API calls needed.
 //
@@ -88,6 +90,12 @@ export const GET: RequestHandler = async ({ url }) => {
     <lastmod>${BUILD_DATE}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
+  </url>`,
+		`  <url>
+    <loc>${siteOrigin}/docs/user-guide/developers/sdk</loc>
+    <lastmod>${BUILD_DATE}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>`
 	];
 

--- a/frontend/apps/web_app/tests/test-account-preflight.spec.ts
+++ b/frontend/apps/web_app/tests/test-account-preflight.spec.ts
@@ -10,7 +10,7 @@
  */
 export {};
 
-const { test } = require('./helpers/cookie-audit');
+const { test, expect } = require('./helpers/cookie-audit');
 const { getTestAccount } = require('./signup-flow-helpers');
 const { loginToTestAccount } = require('./helpers/chat-test-helpers');
 
@@ -28,6 +28,12 @@ test('configured account can complete password and OTP login', async ({ page }: 
 	};
 
 	log('Starting account preflight.', { email });
+	await page.setViewportSize({ width: 1440, height: 900 });
 	await loginToTestAccount(page, log, async () => undefined, { waitForEditor: false });
 	log('Account preflight login succeeded.', { email });
+
+	await expect(page.getByTestId('header-github-link')).toBeVisible({ timeout: 15000 });
+	await expect(page.getByTestId('referral-cta')).toBeVisible({ timeout: 15000 });
+	await expect(page.getByTestId('referral-cta')).toContainText(/Get free credits/i);
+	log('Authenticated wide header actions are visible.', { email });
 });

--- a/frontend/apps/web_app/tests/test-account-preflight.spec.ts
+++ b/frontend/apps/web_app/tests/test-account-preflight.spec.ts
@@ -36,4 +36,11 @@ test('configured account can complete password and OTP login', async ({ page }: 
 	await expect(page.getByTestId('referral-cta')).toBeVisible({ timeout: 15000 });
 	await expect(page.getByTestId('referral-cta')).toContainText(/Get free credits/i);
 	log('Authenticated wide header actions are visible.', { email });
+
+	await page.getByTestId('profile-container').click();
+	await expect(page.getByTestId('settings-menu')).toBeVisible({ timeout: 10000 });
+	await expect(page.getByTestId('header-github-link')).toBeVisible({ timeout: 10000 });
+	await expect(page.getByTestId('referral-cta')).toBeVisible({ timeout: 10000 });
+	await expect(page.getByTestId('referral-cta')).toContainText(/Get free credits/i);
+	log('Authenticated wide header actions stay visible while settings are open.', { email });
 });

--- a/frontend/packages/openmates-cli/README.md
+++ b/frontend/packages/openmates-cli/README.md
@@ -162,16 +162,23 @@ runtime.
 ### Install a server
 
 ```bash
-openmates server install --path ~/openmates
-openmates server install --role core --profile production --path ~/openmates
-openmates server start --path ~/openmates
-openmates server status --path ~/openmates
+openmates server install
+openmates server start
+openmates server status
 ```
 
-Default installs use prebuilt GHCR images and do not require Git or a source
-checkout. The installer writes a runtime directory, creates `.env`, generates
-local secrets, saves the self-host API target in `~/.openmates/server.json`, and
-prints the first invite code.
+The default install path is `~/openmates`. Use `--path <folder>` only when you
+want to install somewhere else:
+
+```bash
+openmates server install --path /opt/openmates
+openmates server start --path /opt/openmates
+```
+
+Default installs use prebuilt GHCR images and do not require Git, a source
+checkout, or cloud-only deployment flags. The installer writes a runtime
+directory, creates `.env`, generates local secrets, saves the self-host API
+target in `~/.openmates/server.json`, and prints the first invite code.
 
 After startup, open:
 
@@ -183,7 +190,7 @@ After startup, open:
 The first invite creates a normal user. Promote your account separately:
 
 ```bash
-openmates server make-admin your@email.com --path ~/openmates
+openmates server make-admin your@email.com
 ```
 
 ### Add AI providers or local models
@@ -200,7 +207,7 @@ SECRET__GOOGLE_AI_STUDIO__API_KEY=...
 ```
 
 ```bash
-openmates server restart --path ~/openmates
+openmates server restart
 ```
 
 Or add a local OpenAI-compatible model served by Ollama, LM Studio, or another
@@ -215,33 +222,20 @@ openmates server ai models test alibaba/qwen3-8b-local
 ### Operate and update a server
 
 ```bash
-openmates server logs --path ~/openmates --tail 200
-openmates server logs --path ~/openmates --container api --follow
-openmates server preflight --path ~/openmates --role core
-openmates server backup --path ~/openmates --role core
-openmates server backup list --path ~/openmates --role core
-openmates server update --path ~/openmates --dry-run
-openmates server update --path ~/openmates
-openmates server update --path ~/openmates --image-tag v0.14.0
-openmates server update --path ~/openmates --channel dev
-openmates server stop --path ~/openmates
-openmates server uninstall --path ~/openmates --yes
+openmates server logs --tail 200
+openmates server logs --container api --follow
+openmates server update --dry-run
+openmates server update
+openmates server backup
+openmates server stop
 ```
 
-Image-mode updates refresh the packaged runtime template, update
-`OPENMATES_IMAGE_TAG`, pull prebuilt images, restart containers, and wait for
-health checks. Before replacing data-bearing roles, the CLI creates a rotating
-latest pre-update backup unless explicitly skipped by the update path.
+Updates pull the matching prebuilt images, restart containers, and wait for
+health checks. Before replacing data-bearing services, the CLI creates a
+rotating pre-update backup.
 
-For source-mode contributor installs:
-
-```bash
-openmates server install --from-source --path ~/openmates-source
-openmates server install --source-path /path/to/OpenMates --path /tmp/openmates-selfhost
-openmates server restart --path ~/openmates-source --rebuild
-```
-
-Source mode uses Git and rebuilds Docker images locally.
+Run `openmates server --help` or read the self-hosting docs for advanced server
+operations beyond the default install/start/update flow.
 
 ## Targets and Environment Variables
 

--- a/frontend/packages/openmates-cli/README.md
+++ b/frontend/packages/openmates-cli/README.md
@@ -1,65 +1,288 @@
 # openmates
 
-Terminal CLI and Node.js SDK for OpenMates. Use it to pair-login, create or continue encrypted chats, run app skills, manage safe account settings, browse docs, and administer self-hosted installs.
+<img src="https://openmates.org/favicon.png" alt="OpenMates" width="72">
+
+Terminal CLI for OpenMates. Use it to chat from your shell, run app skills,
+inspect encrypted account data, export chats, browse docs, and install or manage
+self-hosted OpenMates servers.
+
+[OpenMates](https://openmates.org) | [CLI docs](https://openmates.org/docs/user-guide/cli) | [Self-hosting docs](https://openmates.org/docs/self-hosting/setup) | [Source](https://github.com/glowingkitty/OpenMates/tree/dev/frontend/packages/openmates-cli)
 
 ## Install
 
 ```bash
 npm install -g openmates
-openmates
-openmates login
 ```
 
-Run plain `openmates` in an interactive terminal to open the full-screen chat UI. Use `/examples` to browse public example chats, type into any example to continue it as a new real or anonymous chat, `/login` for pair-auth, `/signup` for guided account creation, and `/embed <id>` to jump to full embed details. If stdin or stdout is redirected, plain `openmates` prints a script-friendly quickstart instead of entering the TUI.
+Requires Node.js 20 or newer.
 
-Without a session, `openmates chats list`, `show`, and `open` display clearly labeled public example chats from the web app. Login uses pair-auth: the CLI shows a QR code or PIN, and you approve it in the web app. To create a new account from the terminal, run `openmates signup`; passwords and recovery secrets are collected through hidden prompts, never command-line flags.
-
-## First Commands
+Install the latest dev prerelease:
 
 ```bash
-openmates whoami --json
-openmates chats list
-openmates chats show example-gigantic-airplanes
-openmates chats new "Help me plan my day"
-openmates chats new "Review @./src/app.ts"
-openmates chats send --chat <chat-id> "continue"
-openmates embeds show <embed-id>
-openmates apps list
-openmates apps ai ask "What is Docker?"
-openmates apps code run --language python --code 'print("Hello")'
-openmates settings account export data --json
-openmates learning-mode status --json
-openmates settings memories list --json
-openmates docs list
-openmates remote-access start --path ./my-repo --source-id repo-1 --local-only
-openmates benchmark model google/gemini-3.5-flash --dry-run --json
-openmates server install
+npm install -g openmates@alpha
 ```
 
-Run `openmates --help` or `openmates <command> --help` for the full command surface. Benchmark commands also support `openmates benchmark --help` for suite, comparison, judge, and spend-confirmation options.
+Update an existing global install:
 
-## Environments
+```bash
+openmates update
+openmates update --dry-run
+openmates update --version alpha
+```
 
-The CLI derives the web app URL from the API URL so pair-auth lands on the matching backend.
+## Quick Start
+
+Run the interactive terminal chat UI:
+
+```bash
+openmates
+```
+
+In the TUI, use `/help`, `/examples`, `/login`, `/signup`, and `/exit`.
+When stdin or stdout is redirected, plain `openmates` prints a script-friendly
+quickstart instead of opening the TUI.
+
+Login with pair-auth:
+
+```bash
+openmates login
+openmates whoami --json
+```
+
+The CLI displays a QR code or pair PIN. Approve it in the OpenMates web app.
+During login, the CLI never asks for your account password.
+
+Create a new account from the terminal:
+
+```bash
+openmates signup
+```
+
+Signup collects passwords, 2FA codes, backup codes, and recovery keys through
+hidden prompts or owner-only files, not command-line password flags.
+
+## Common Commands
+
+### Chat from the shell
+
+```bash
+openmates chats list
+openmates chats show last
+openmates chats new "Help me plan my day"
+openmates chats send --chat <chat-id> "continue"
+openmates chats incognito "Answer without saving this chat"
+```
+
+Without login, `openmates chats list`, `show`, and `open` display clearly labeled
+public example chats from the web app.
+
+### Attach local files and mentions
+
+```bash
+openmates chats new "@Sophia review @./src/app.ts"
+openmates chats new "@Best summarize @./notes.md"
+openmates mentions list
+```
+
+The CLI redacts likely secrets before sending file content. Private keys and
+high-risk files are blocked by default.
+
+### Export, share, and delete chats
+
+```bash
+openmates chats download last --output ~/exports
+openmates chats download <chat-id> --zip
+openmates chats share last --expires 604800
+openmates chats delete <chat-id> --yes
+```
+
+Exports include YAML and Markdown. When present, code embeds and video
+transcripts are written as separate files.
+
+### Run app skills
+
+```bash
+openmates apps list
+openmates apps web search "latest AI news"
+openmates apps ai ask "What is Docker?"
+openmates apps code run --language python --code 'print("Hello from CLI")'
+openmates apps travel search_connections --input '{"requests":[{"legs":[{"origin":"BER","destination":"LHR","date":"2026-04-15"}]}]}'
+```
+
+App commands use your logged-in session by default. For non-interactive scripts,
+create an API key in **Settings > Developers > API Keys**, then pass
+`--api-key <key>` or set `OPENMATES_API_KEY`.
+
+### Account settings and data
+
+```bash
+openmates settings --help
+openmates settings account export data --json
+openmates settings memories list --json
+openmates learning-mode status --json
+openmates docs search "API keys"
+```
+
+Predefined settings commands are supported. Raw settings path passthrough is not
+available. Security-sensitive actions such as passkey management, password
+changes, API key creation, device approvals, and card checkout stay in the web
+app. The code-level guard is `BLOCKED_SETTINGS_MUTATE_PATHS` in `src/client.ts`.
+
+### Embeds, docs, and benchmarks
+
+```bash
+openmates embeds show <embed-id>
+openmates embeds share <embed-id> --expires 604800
+openmates docs list
+openmates docs download cli/server-management
+openmates benchmark model google/gemini-3.5-flash --dry-run --json
+```
+
+Benchmark commands run real product-path model calls when not in `--dry-run`, so
+review the spend confirmation before live runs.
+
+### Local source bridge
+
+```bash
+openmates remote-access start --path ./my-repo --source-id repo-1 --local-only
+openmates remote-access status --json
+openmates remote-access search --source repo-1 "TODO" --limit 20
+```
+
+`openmates remote-access` stores source metadata under
+`~/.openmates/remote-sources.json`, searches with `rg` inside the approved root,
+and does not upload repository files by default.
+
+## Self-Host Server Management
+
+The CLI can install and manage a self-hosted OpenMates server. Server commands do
+not require an OpenMates cloud login. They operate on the local Docker Compose
+runtime.
+
+### Install a server
+
+```bash
+openmates server install --path ~/openmates
+openmates server install --role core --profile production --path ~/openmates
+openmates server start --path ~/openmates
+openmates server status --path ~/openmates
+```
+
+Default installs use prebuilt GHCR images and do not require Git or a source
+checkout. The installer writes a runtime directory, creates `.env`, generates
+local secrets, saves the self-host API target in `~/.openmates/server.json`, and
+prints the first invite code.
+
+After startup, open:
+
+| Service | URL |
+| --- | --- |
+| Web app | `http://localhost:5173` |
+| Backend API | `http://localhost:8000` |
+
+The first invite creates a normal user. Promote your account separately:
+
+```bash
+openmates server make-admin your@email.com --path ~/openmates
+```
+
+### Add AI providers or local models
+
+A fresh self-hosted server can start without provider keys, but AI chat and model
+processing stay unavailable until at least one real model provider is configured.
+
+Edit `~/openmates/.env` and add a provider key, then restart:
+
+```env
+SECRET__OPENAI__API_KEY=sk-...
+SECRET__ANTHROPIC__API_KEY=sk-ant-...
+SECRET__GOOGLE_AI_STUDIO__API_KEY=...
+```
+
+```bash
+openmates server restart --path ~/openmates
+```
+
+Or add a local OpenAI-compatible model served by Ollama, LM Studio, or another
+runtime:
+
+```bash
+openmates server ai models add
+openmates server ai models list
+openmates server ai models test alibaba/qwen3-8b-local
+```
+
+### Operate and update a server
+
+```bash
+openmates server logs --path ~/openmates --tail 200
+openmates server logs --path ~/openmates --container api --follow
+openmates server preflight --path ~/openmates --role core
+openmates server backup --path ~/openmates --role core
+openmates server backup list --path ~/openmates --role core
+openmates server update --path ~/openmates --dry-run
+openmates server update --path ~/openmates
+openmates server update --path ~/openmates --image-tag v0.14.0
+openmates server update --path ~/openmates --channel dev
+openmates server stop --path ~/openmates
+openmates server uninstall --path ~/openmates --yes
+```
+
+Image-mode updates refresh the packaged runtime template, update
+`OPENMATES_IMAGE_TAG`, pull prebuilt images, restart containers, and wait for
+health checks. Before replacing data-bearing roles, the CLI creates a rotating
+latest pre-update backup unless explicitly skipped by the update path.
+
+For source-mode contributor installs:
+
+```bash
+openmates server install --from-source --path ~/openmates-source
+openmates server install --source-path /path/to/OpenMates --path /tmp/openmates-selfhost
+openmates server restart --path ~/openmates-source --rebuild
+```
+
+Source mode uses Git and rebuilds Docker images locally.
+
+## Targets and Environment Variables
+
+The CLI derives the web app URL from the API URL so pair-auth opens the matching
+environment.
 
 | Target | Command prefix |
 | --- | --- |
-| Production | _(none)_ |
+| OpenMates cloud | none |
 | Dev server | `OPENMATES_API_URL=https://api.dev.openmates.org` |
-| Installed self-hosted server | _(none after `openmates server install`)_ |
+| Installed self-hosted server | none after `openmates server install` |
 | Remote self-hosted server | `OPENMATES_API_URL=https://api.example.com` |
 
-After `openmates server install`, fresh CLI commands default to that self-hosted server (`http://localhost:8000`) unless you already have a saved login session, set `OPENMATES_API_URL`, or pass `--api-url <url>`. App-skill execution can use your logged-in session, `--api-key <key>`, or `OPENMATES_API_KEY`.
+Useful variables:
 
-## Safety Limits
+| Variable | Purpose |
+| --- | --- |
+| `OPENMATES_API_URL` | Override the API endpoint. |
+| `OPENMATES_APP_URL` | Override the derived web app URL for pair-auth. |
+| `OPENMATES_API_KEY` | API key for app-skill and SDK calls. |
 
-Predefined settings commands are supported; raw `settings get/post/patch/delete` passthrough is intentionally unavailable. High-risk or browser-only flows such as passkey management, password changes, API key creation, device approvals, and card checkout stay in the web app. The code-level guard is `BLOCKED_SETTINGS_MUTATE_PATHS` in `src/client.ts`.
+You can also pass `--api-url <url>`, `--api-key <key>`, and `--json` to most
+commands.
 
-`openmates remote-access` is a local Project source bridge. It stores source metadata under `~/.openmates/remote-sources.json`, searches with `rg` inside the approved source root, and does not upload repository files by default.
+## Local Files
 
-## SDK
+The CLI stores local state under `~/.openmates/` with owner-only permissions.
 
-The package also exports a lazy API-key SDK. Create an API key in OpenMates under Settings > Developers > API Keys, then set `OPENMATES_API_KEY` or pass `apiKey` explicitly. New SDK devices must be approved in Settings > Developers > Devices before API-key calls are allowed.
+| File | Purpose |
+| --- | --- |
+| `session.json` | Pair-auth CLI session. |
+| `sync_cache.json` | Cached decrypted account data for CLI use. |
+| `server.json` | Self-host install path and local API target. |
+| `remote-sources.json` | Local source bridge metadata. |
+
+Treat these files like account credentials.
+
+## Node.js SDK
+
+The npm package also exports an API-key SDK for Node.js. Use it when you want a
+programmatic client instead of shell commands.
 
 ```ts
 import { OpenMates } from "openmates";
@@ -69,23 +292,29 @@ const om = new OpenMates({ apiKey: process.env.OPENMATES_API_KEY });
 const search = await om.apps.web.search({
   requests: [{ query: "OpenMates SDK examples" }],
 });
+
+const response = await om.chats.send("Summarize this release note draft.");
 ```
 
-SDK methods authenticate lazily; there is no `connect()` call.
+SDK chats are non-persistent by default. Use `saveToAccount: true` only when you
+intentionally want the chat saved to the OpenMates account.
 
-```ts
-const latestChats = await om.chats.list(); // defaults to 10
-const allChats = await om.chats.list({ limit: 0 });
+## Versioning
 
-await om.chats.send("Summarize this release note draft.");
+OpenMates shows the short product line, for example `v0.14`, in the web app.
+The npm package uses exact artifact versions:
 
-await om.chats.send("Create a project kickoff checklist.", { saveToAccount: true });
+- `0.14.N-alpha.0` is a prerelease from the `dev` branch published under the
+  `alpha` npm tag.
+- `0.14.N` is a stable release from `main` published under the `latest` npm tag.
 
-await om.billing.overview();
-await om.billing.invoices();
-await om.docs.search("api keys");
-```
+Install stable releases with `npm install -g openmates`. Install prereleases with
+`npm install -g openmates@alpha`.
 
-New SDK chats are non-persistent by default. Use `saveToAccount: true` only when you intentionally want the chat saved to the OpenMates account.
+## More Documentation
 
-Source docs: `docs/user-guide/developers/sdk.md` in the OpenMates repository.
+- [CLI guide](https://openmates.org/docs/user-guide/cli)
+- [Self-hosting setup](https://openmates.org/docs/self-hosting/setup)
+- [SDK guide](https://openmates.org/docs/user-guide/developers/sdk)
+- [Source code](https://github.com/glowingkitty/OpenMates/tree/dev/frontend/packages/openmates-cli)
+- [Issue tracker](https://github.com/glowingkitty/OpenMates/issues)

--- a/frontend/packages/ui/src/components/Header.svelte
+++ b/frontend/packages/ui/src/components/Header.svelte
@@ -527,7 +527,7 @@
                 {#if !docsMode}
                     <div
                         class="right-section"
-                        class:hidden={context !== 'webapp' || $authStore.isAuthenticated || $demoMode || $loginInterfaceOpen || $introBannerVisible}
+                        class:hidden={context !== 'webapp' || $authStore.isAuthenticated || $loginInterfaceOpen || $introBannerVisible}
                     >
                         {#if !isMobile}
                             <a

--- a/frontend/packages/ui/src/components/Settings.svelte
+++ b/frontend/packages/ui/src/components/Settings.svelte
@@ -40,7 +40,7 @@ changes to the documentation (to keep the documentation up to date).
     import { cubicOut } from 'svelte/easing';
     import { authStore, isCheckingAuth, logout } from '../stores/authStore'; // Import logout action
     import { isMenuOpen } from '../stores/menuState';
-    // import { getWebsiteUrl, routes } from '../config/links'; // Unused - help button disabled
+    import { externalLinks } from '../config/links';
     import { tooltip } from '../actions/tooltip';
     import { isInSignupProcess, isLoggingOut, showSignupFooter } from '../stores/signupState';
     import { userProfile, updateProfile } from '../stores/userProfile';
@@ -2697,36 +2697,46 @@ changes to the documentation (to keep the documentation up to date).
     	out:fade
     >
     <div bind:this={profileContainerWrapper}> <!-- Bind the wrapper -->
-        {#if showLearningModeCta || showReferralCta}
-            {#key showLearningModeCta ? 'learning-mode' : 'referral'}
-                {#if showLearningModeCta}
-                    <button
-                        type="button"
-                        class="referral-cta learning-mode-cta compact"
-                        data-testid="learning-mode-header-cta"
-                        aria-label={$text('settings.learning_mode')}
-                        onclick={openLearningModeSettings}
-                        in:fade={{ duration: 180 }}
-                        out:fade={{ duration: 140 }}
-                    >
-                        <span class="learning-mode-cta-icon" aria-hidden="true"></span>
-                        <span class="referral-cta-text">{$text('settings.learning_mode')}</span>
-                    </button>
-                {:else}
-                    <button
-                        type="button"
-                        class="referral-cta"
-                        data-testid="referral-cta"
-                        aria-label={$text('settings.billing.get_free_credits')}
-                        onclick={openReferralSettings}
-                        in:fade={{ duration: 180 }}
-                        out:fade={{ duration: 140 }}
-                    >
-                        <span class="referral-cta-icon" aria-hidden="true"></span>
-                        <span class="referral-cta-text">{$text('settings.billing.get_free_credits')}</span>
-                    </button>
-                {/if}
-            {/key}
+        {#if visuallyAuthenticated}
+            <a
+                class="header-github-link"
+                data-testid="header-github-link"
+                href={externalLinks.github}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open OpenMates GitHub repository"
+                in:fade={{ duration: 180 }}
+                out:fade={{ duration: 140 }}
+            >
+                <span class="header-github-icon" aria-hidden="true"></span>
+            </a>
+        {/if}
+        {#if showReferralCta}
+            <button
+                type="button"
+                class="referral-cta"
+                data-testid="referral-cta"
+                aria-label={$text('settings.billing.get_free_credits')}
+                onclick={openReferralSettings}
+                in:fade={{ duration: 180 }}
+                out:fade={{ duration: 140 }}
+            >
+                <span class="referral-cta-icon" aria-hidden="true"></span>
+                <span class="referral-cta-text">{$text('settings.billing.get_free_credits')}</span>
+            </button>
+        {:else if showLearningModeCta}
+            <button
+                type="button"
+                class="referral-cta learning-mode-cta compact"
+                data-testid="learning-mode-header-cta"
+                aria-label={$text('settings.learning_mode')}
+                onclick={openLearningModeSettings}
+                in:fade={{ duration: 180 }}
+                out:fade={{ duration: 140 }}
+            >
+                <span class="learning-mode-cta-icon" aria-hidden="true"></span>
+                <span class="referral-cta-text">{$text('settings.learning_mode')}</span>
+            </button>
         {/if}
      	<div
 			id="settings-menu-toggle"
@@ -3055,7 +3065,7 @@ changes to the documentation (to keep the documentation up to date).
     .referral-cta {
         position: absolute;
         top: 4px;
-        inset-inline-end: 58px;
+        inset-inline-end: 102px;
         height: 42px;
         max-width: 185px;
         min-width: 24px;
@@ -3078,6 +3088,41 @@ changes to the documentation (to keep the documentation up to date).
 
     .referral-cta:hover {
         transform: translateY(-1px);
+    }
+
+    .header-github-link {
+        position: absolute;
+        top: 4px;
+        inset-inline-end: 58px;
+        width: 42px;
+        height: 42px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--radius-full);
+        color: var(--color-primary-end);
+        text-decoration: none;
+        transition:
+            opacity var(--duration-normal) var(--easing-default),
+            transform var(--duration-normal) var(--easing-default);
+    }
+
+    .header-github-link:hover {
+        transform: translateY(-1px);
+    }
+
+    .header-github-icon {
+        width: 22px;
+        height: 22px;
+        background: var(--color-primary);
+        -webkit-mask-image: url('@openmates/ui/static/icons/github.svg');
+        mask-image: url('@openmates/ui/static/icons/github.svg');
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        -webkit-mask-position: center;
+        mask-position: center;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
     }
 
     .referral-cta.compact {
@@ -3148,7 +3193,8 @@ changes to the documentation (to keep the documentation up to date).
         }
     }
 
-    .profile-container-wrapper:has(.profile-container.menu-open) .referral-cta {
+    .profile-container-wrapper:has(.profile-container.menu-open) .referral-cta,
+    .profile-container-wrapper:has(.profile-container.menu-open) .header-github-link {
         opacity: 0;
         pointer-events: none;
     }

--- a/frontend/packages/ui/src/components/Settings.svelte
+++ b/frontend/packages/ui/src/components/Settings.svelte
@@ -3193,12 +3193,6 @@ changes to the documentation (to keep the documentation up to date).
         }
     }
 
-    .profile-container-wrapper:has(.profile-container.menu-open) .referral-cta,
-    .profile-container-wrapper:has(.profile-container.menu-open) .header-github-link {
-        opacity: 0;
-        pointer-events: none;
-    }
-
     .profile-container.menu-open {
         opacity: 0;
         pointer-events: none;

--- a/frontend/packages/ui/src/components/settings/SettingsFooter.svelte
+++ b/frontend/packages/ui/src/components/settings/SettingsFooter.svelte
@@ -133,75 +133,87 @@
 
     <!-- For everyone -->
     <div class="submenu-group">
-        <h3>{@html $text('footer.sections.for_everyone')}</h3>
+        <h3>{$text('footer.sections.for_everyone')}</h3>
         <a
             href={externalLinks.instagram}
             class="submenu-link"
             target="_blank"
             rel="noopener noreferrer"
-        >{@html $text('settings.instagram')}</a>
+        >{$text('settings.instagram')}</a>
         <a
             href={externalLinks.discord}
             class="submenu-link"
             target="_blank"
             rel="noopener noreferrer"
-        >{@html $text('common.discord')}</a>
+        >{$text('common.discord')}</a>
         <a
             href={externalLinks.meetup}
             class="submenu-link"
             target="_blank"
             rel="noopener noreferrer"
-        >{@html $text('settings.meetup')}</a>
+        >{$text('settings.meetup')}</a>
         <a
             href={externalLinks.bluesky}
             class="submenu-link"
             target="_blank"
             rel="noopener noreferrer"
-        >{@html $text('settings.bluesky')}</a>
+        >{$text('settings.bluesky')}</a>
         <a
             href={externalLinks.mastodon}
             class="submenu-link"
             target="_blank"
             rel="noopener noreferrer"
-        >{@html $text('settings.mastodon')}</a>
+        >{$text('settings.mastodon')}</a>
         <a
             href={externalLinks.pixelfed}
             class="submenu-link"
             target="_blank"
             rel="noopener noreferrer"
-        >{@html $text('settings.pixelfed')}</a>
+        >{$text('settings.pixelfed')}</a>
     </div>
 
     <!-- For developers -->
     <div class="submenu-group">
-        <h3>{@html $text('footer.sections.for_developers')}</h3>
+        <h3>{$text('footer.sections.for_developers')}</h3>
         <a
             href={getApiDocsUrl()}
             class="submenu-link"
             target="_blank"
             rel="noopener noreferrer"
-        >{@html $text('settings.api_docs')}</a>
+        >{$text('settings.api_docs')}</a>
         <a
             href={externalLinks.github}
             class="submenu-link"
             target="_blank"
             rel="noopener noreferrer"
-        >{@html $text('common.github')}</a>
+        >{$text('common.github')}</a>
+        <a
+            href={externalLinks.npmPackage}
+            class="submenu-link"
+            target="_blank"
+            rel="noopener noreferrer"
+        >{$text('settings.npm_package')}</a>
+        <a
+            href={externalLinks.pypiPackage}
+            class="submenu-link"
+            target="_blank"
+            rel="noopener noreferrer"
+        >{$text('settings.pypi_package')}</a>
         <a
             href={externalLinks.signal}
             class="submenu-link"
             target="_blank"
             rel="noopener noreferrer"
-        >{@html $text('settings.signal')}</a>
+        >{$text('settings.signal')}</a>
     </div>
 
     <!-- Contact email -->
     <div class="submenu-group">
-        <h3>{@html $text('common.contact')}</h3>
+        <h3>{$text('common.contact')}</h3>
         <a
             href={externalLinks.email}
             class="submenu-link"
-        >{@html $text('common.email')}</a>
+        >{$text('common.email')}</a>
     </div>
 
     <!-- Legal section: Only show for non-self-hosted instances -->
@@ -211,22 +223,22 @@
     <!-- - No terms of service: no third-party service relationship exists -->
     {#if !isSelfHosted}
         <div class="submenu-group">
-            <h3>{@html $text('common.legal')}</h3>
+            <h3>{$text('common.legal')}</h3>
             <a 
                 href={getWebsiteUrl(externalLinks.legal.imprint)} 
                 class="submenu-link" 
                 onclick={(e) => handleLegalLinkClick(e, 'imprint')}
-            >{@html $text('common.imprint')}</a>
+            >{$text('common.imprint')}</a>
             <a 
                 href={getWebsiteUrl(externalLinks.legal.privacyPolicy)} 
                 class="submenu-link" 
                 onclick={(e) => handleLegalLinkClick(e, 'privacy')}
-            >{@html $text('common.privacy')}</a>
+            >{$text('common.privacy')}</a>
             <a 
                 href={getWebsiteUrl(externalLinks.legal.terms)} 
                 class="submenu-link" 
                 onclick={(e) => handleLegalLinkClick(e, 'terms')}
-            >{@html $text('common.terms_and_conditions')}</a>
+            >{$text('common.terms_and_conditions')}</a>
         </div>
     {/if}
 

--- a/frontend/packages/ui/src/config/links.ts
+++ b/frontend/packages/ui/src/config/links.ts
@@ -60,6 +60,8 @@ export const externalLinks = {
   signal:
     sharedUrls?.urls?.contact?.signal ||
     "https://signal.group/#CjQKIOlYZ63Rz7sibDjQ680wO1a0NcKxtfL0in2BA6Yvbr82EhDNd6GJYtaPfHn4BFcsETQq",
+  npmPackage: "https://www.npmjs.com/package/openmates",
+  pypiPackage: "https://pypi.org/project/openmates/",
   // element: sharedUrls?.urls?.contact?.element || "????",
 
   // Contact

--- a/frontend/packages/ui/src/i18n/sources/settings/main.yml
+++ b/frontend/packages/ui/src/i18n/sources/settings/main.yml
@@ -3237,6 +3237,54 @@ github:
   sv: GitHub
   he: GitHub
   verified_by_human: []
+npm_package:
+  context: npm package link in settings footer
+  en: npm
+  de: npm
+  zh: npm
+  es: npm
+  fr: npm
+  pt: npm
+  ru: npm
+  ja: npm
+  ko: npm
+  it: npm
+  tr: npm
+  vi: npm
+  id: npm
+  pl: npm
+  nl: npm
+  ar: npm
+  hi: npm
+  th: npm
+  cs: npm
+  sv: npm
+  he: npm
+  verified_by_human: []
+pypi_package:
+  context: PyPI package link in settings footer
+  en: PyPI
+  de: PyPI
+  zh: PyPI
+  es: PyPI
+  fr: PyPI
+  pt: PyPI
+  ru: PyPI
+  ja: PyPI
+  ko: PyPI
+  it: PyPI
+  tr: PyPI
+  vi: PyPI
+  id: PyPI
+  pl: PyPI
+  nl: PyPI
+  ar: PyPI
+  hi: PyPI
+  th: PyPI
+  cs: PyPI
+  sv: PyPI
+  he: PyPI
+  verified_by_human: []
 instagram:
   context: Instagram contact link
   en: Instagram

--- a/frontend/packages/ui/src/i18n/sources/signup/main.yml
+++ b/frontend/packages/ui/src/i18n/sources/signup/main.yml
@@ -48,27 +48,27 @@ test_for_free:
   verified_by_human: []
 version_title:
   context: Version title on alpha disclaimer page
-  en: v0.14.0
-  de: v0.14.0
-  zh: v0.14.0
-  es: v0.14.0
-  fr: v0.14.0
-  pt: v0.14.0
-  ru: v0.14.0
-  ja: v0.14.0
-  ko: v0.14.0
-  it: v0.14.0
-  tr: v0.14.0
-  vi: v0.14.0
-  id: v0.14.0
-  pl: v0.14.0
-  nl: v0.14.0
-  ar: v0.14.0
-  hi: v0.14.0
-  th: v0.14.0
-  cs: v0.14.0
-  sv: "v0.14.0"
-  he: v0.14.0
+  en: v0.14
+  de: v0.14
+  zh: v0.14
+  es: v0.14
+  fr: v0.14
+  pt: v0.14
+  ru: v0.14
+  ja: v0.14
+  ko: v0.14
+  it: v0.14
+  tr: v0.14
+  vi: v0.14
+  id: v0.14
+  pl: v0.14
+  nl: v0.14
+  ar: v0.14
+  hi: v0.14
+  th: v0.14
+  cs: v0.14
+  sv: "v0.14"
+  he: v0.14
   verified_by_human: []
 domain_not_allowed:
   context: Error message shown when the domain is not allowed to sign up

--- a/packages/openmates-python/README.md
+++ b/packages/openmates-python/README.md
@@ -2,7 +2,10 @@
 
 <img src="https://openmates.org/favicon.png" alt="OpenMates" width="72">
 
-Python SDK for OpenMates API-key access to app skills and encrypted chat workflows.
+Python SDK for OpenMates: run app skills, create encrypted chats, inspect usage,
+and automate everyday OpenMates tasks from Python.
+
+[OpenMates](https://openmates.org) | [SDK docs](https://openmates.org/docs/user-guide/developers/sdk) | [Source](https://github.com/glowingkitty/OpenMates/tree/dev/packages/openmates-python)
 
 ## Install
 
@@ -10,9 +13,18 @@ Python SDK for OpenMates API-key access to app skills and encrypted chat workflo
 pip install openmates
 ```
 
-## API Key
+Install the latest prerelease from the `dev` channel:
 
-Create an API key in OpenMates under Settings > Developers > API Keys. The guided flow asks for scope, credit limit, and expiration before revealing the key once.
+```bash
+pip install --pre --upgrade openmates
+```
+
+## Quick Start
+
+1. Open OpenMates.
+2. Go to **Settings > Developers > API Keys**.
+3. Create an API key with the scopes and credit limit your script needs.
+4. Copy the key immediately. OpenMates only shows it once.
 
 Set the key in your environment:
 
@@ -20,9 +32,7 @@ Set the key in your environment:
 export OPENMATES_API_KEY="sk-api-..."
 ```
 
-New SDK devices are blocked until approved in Settings > Developers > Devices.
-
-## Usage
+Run your first request:
 
 ```python
 from openmates import OpenMates
@@ -32,42 +42,170 @@ om = OpenMates()  # reads OPENMATES_API_KEY
 result = om.apps.web.search({
     "requests": [{"query": "OpenMates SDK examples"}],
 })
+
+print(result)
 ```
 
-SDK methods authenticate lazily; there is no `connect()` call.
+SDK methods authenticate lazily. You do not need to call `connect()`.
 
-List encrypted account chats. The default limit is 10; pass `limit=0` only when you intentionally want all account chats:
+New SDK devices may need approval in **Settings > Developers > Devices** before
+they can access encrypted account data.
 
-```python
-latest_chats = om.chats.list()
-all_chats = om.chats.list(limit=0)
-```
+## Common Examples
 
-Create a non-persistent chat. This is the default and does not save the transcript to your OpenMates account:
+### Send a private chat message
+
+By default, `chats.send()` creates a non-persistent chat. It does not save the
+transcript to your OpenMates account.
 
 ```python
 response = om.chats.send("Summarize this release note draft.")
 print(response.content)
 ```
 
-Create a saved account chat explicitly:
+Save the chat explicitly when you want it in your account history:
 
 ```python
-om.chats.send("Create a project kickoff checklist.", save_to_account=True)
-
-om.billing.overview()
-om.billing.invoices()
-om.docs.search("api keys")
+response = om.chats.send(
+    "Draft a checklist for launching our beta.",
+    save_to_account=True,
+)
 ```
 
-## Errors
+### List and load encrypted chats
 
-The SDK raises `OpenMatesConfigError` for missing configuration and `OpenMatesApiError` for API responses such as expired keys, unapproved devices, missing scopes, or exceeded credit limits.
+```python
+latest_chats = om.chats.list(limit=10)
+chat = om.chats.load(latest_chats[0]["id"])
 
-Full source docs: `docs/user-guide/developers/sdk.md` in the OpenMates repository.
+print(chat["chat"].get("title"))
+```
 
-## Publishing
+Pass `limit=0` only when you intentionally want all account chats.
 
-Maintainers publish this package through PyPI Trusted Publishing from GitHub
-Actions. See `docs/contributing/guides/publish-python-sdk.md` for first-time
-PyPI setup, versioning rules, and the automated `dev`/`main` release flow.
+### Search the web
+
+```python
+search = om.apps.web.search({
+    "requests": [
+        {"query": "privacy-first AI assistants", "count": 5},
+    ],
+})
+```
+
+### Read a web page
+
+```python
+page = om.apps.web.read({
+    "url": "https://openmates.org/docs/user-guide/developers/sdk",
+})
+```
+
+### Search OpenMates docs
+
+```python
+docs = om.docs.search("API keys")
+```
+
+### Check billing and usage
+
+```python
+overview = om.billing.overview()
+invoices = om.billing.invoices()
+```
+
+### Work with memories
+
+```python
+memory_types = om.memories.types()
+saved_memories = om.memories.list(app_id="web")
+```
+
+### Create reminders
+
+```python
+reminder = om.reminders.create({
+    "title": "Review OpenMates SDK usage",
+    "due_at": "2026-07-10T09:00:00Z",
+})
+```
+
+## SDK Areas
+
+| Namespace | Purpose |
+| --- | --- |
+| `om.apps.*` | Generated app-skill methods such as `web.search`, `web.read`, `images.generate`, `pdf.search`, and more. |
+| `om.chats.*` | Encrypted chat list/load/send/export/share/delete helpers. |
+| `om.docs.*` | Search OpenMates documentation. |
+| `om.billing.*` | Usage overview, invoices, and billing metadata. |
+| `om.account.*` | Account info, interests, storage, export helpers. |
+| `om.memories.*` | List, create, update, and delete encrypted memory entries when your API key has memory scopes. |
+| `om.reminders.*` | Create, list, and manage reminders. |
+| `om.connected_accounts.*` | Import connected-account data with explicit user approval flows. |
+| `om.embeds.*` | Inspect and share embed data when available to the API key. |
+| `om.settings.*` | Update supported account settings such as language, theme, model defaults, and chat auto-delete. |
+
+Generated app-skill methods follow the app and skill names from OpenMates. For
+example, the web search skill is `om.apps.web.search(...)` and PDF search is
+`om.apps.pdf.search(...)`.
+
+## API Keys and Scopes
+
+API keys are bearer credentials. Treat them like passwords.
+
+- Store keys in environment variables or a secret manager.
+- Do not commit keys to source control.
+- Use the narrowest scopes and credit limits your script needs.
+- New SDK devices may require approval before they can access encrypted account data.
+
+Common scopes include:
+
+| Scope | Allows |
+| --- | --- |
+| `chat:create_incognito` | Non-persistent SDK chats. |
+| `chat:create_saved` | Saved account chats. |
+| `chat:read_existing` | Listing and loading existing encrypted chats. |
+| `chat:append_existing` | Adding messages to existing saved chats. |
+| `chat:share` | Creating share links. |
+| `memory:read` | Reading memory entries selected by the SDK caller. |
+
+App-skill scopes can allow all apps, a specific app, or a specific skill such as
+`web:search`.
+
+## Error Handling
+
+```python
+from openmates import OpenMates, OpenMatesApiError, OpenMatesConfigError
+
+try:
+    om = OpenMates()
+    print(om.billing.overview())
+except OpenMatesConfigError as error:
+    print(f"Configuration error: {error}")
+except OpenMatesApiError as error:
+    print(f"API error {error.status_code}: {error.data}")
+```
+
+The SDK raises:
+
+- `OpenMatesConfigError` for missing API keys or local key-unwrapping problems.
+- `OpenMatesApiError` for API responses such as expired keys, unapproved devices,
+  missing scopes, or exceeded credit limits.
+
+## Versioning
+
+OpenMates shows the short product line, for example `v0.14`, in the web app.
+Python package artifacts use exact release-line versions:
+
+- `0.14.Na0` is an alpha prerelease from the `dev` branch.
+- `0.14.N` is a stable release from `main`.
+
+Install stable releases with `pip install openmates`. Install prereleases with
+`pip install --pre openmates`.
+
+## More Documentation
+
+- [Full SDK guide](https://openmates.org/docs/user-guide/developers/sdk)
+- [OpenMates docs](https://openmates.org/docs)
+- [Source code](https://github.com/glowingkitty/OpenMates/tree/dev/packages/openmates-python)
+- [Issue tracker](https://github.com/glowingkitty/OpenMates/issues)

--- a/packages/openmates-python/README.md
+++ b/packages/openmates-python/README.md
@@ -1,5 +1,7 @@
 # openmates
 
+<img src="https://openmates.org/favicon.png" alt="OpenMates" width="72">
+
 Python SDK for OpenMates API-key access to app skills and encrypted chat workflows.
 
 ## Install

--- a/packages/openmates-python/pyproject.toml
+++ b/packages/openmates-python/pyproject.toml
@@ -11,6 +11,12 @@ requires-python = ">=3.10"
 dependencies = ["requests>=2.31", "cryptography>=41"]
 license = "MIT"
 
+[project.urls]
+Homepage = "https://openmates.org"
+Documentation = "https://openmates.org/docs/user-guide/developers/sdk"
+Source = "https://github.com/glowingkitty/OpenMates/tree/dev/packages/openmates-python"
+Issues = "https://github.com/glowingkitty/OpenMates/issues"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["openmates*"]

--- a/scripts/prepare_cli_publish_version.mjs
+++ b/scripts/prepare_cli_publish_version.mjs
@@ -57,33 +57,56 @@ function parseStableVersion(version) {
   return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
 }
 
-function nextStableVersion(publishedVersions) {
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function releaseLineEntries(publishedVersions) {
   const base = parseStableVersion(config.cli.stableBase);
   if (!base) {
     fail(`cli.stableBase must be a stable npm semver string, got ${config.cli.stableBase}`);
   }
 
-  const patches = publishedVersions
-    .map(parseStableVersion)
-    .filter((version) => version && version.major === base.major && version.minor === base.minor && version.patch >= base.patch)
-    .map((version) => version.patch);
+  const label = config.cli.prereleaseLabel || "alpha";
+  const prereleasePattern = new RegExp(`^(\\d+)\\.(\\d+)\\.(\\d+)-${escapeRegExp(label)}\\.(\\d+)$`);
+  const entries = [];
 
-  if (!patches.length) return config.cli.stableBase;
-  return `${base.major}.${base.minor}.${Math.max(...patches) + 1}`;
+  for (const publishedVersion of publishedVersions) {
+    const stable = parseStableVersion(publishedVersion);
+    if (stable && stable.major === base.major && stable.minor === base.minor && stable.patch >= base.patch) {
+      entries.push({ patch: stable.patch, stable: true });
+      continue;
+    }
+
+    const prerelease = publishedVersion.match(prereleasePattern);
+    if (!prerelease) continue;
+    const major = Number(prerelease[1]);
+    const minor = Number(prerelease[2]);
+    const patch = Number(prerelease[3]);
+    if (major === base.major && minor === base.minor && patch >= base.patch) {
+      entries.push({ patch, stable: false });
+    }
+  }
+
+  return { base, entries };
+}
+
+function nextStableVersion(publishedVersions) {
+  const { base, entries } = releaseLineEntries(publishedVersions);
+  if (!entries.length) return config.cli.stableBase;
+
+  const latestPatch = Math.max(...entries.map((entry) => entry.patch));
+  const latestPatchIsStable = entries.some((entry) => entry.patch === latestPatch && entry.stable);
+  const patch = latestPatchIsStable ? latestPatch + 1 : latestPatch;
+  return `${base.major}.${base.minor}.${patch}`;
 }
 
 function nextPrereleaseVersion(publishedVersions) {
-  const targetStable = nextStableVersion(publishedVersions);
+  const { base, entries } = releaseLineEntries(publishedVersions);
+  const latestPatch = entries.length ? Math.max(...entries.map((entry) => entry.patch)) : base.patch - 1;
+  const targetStable = `${base.major}.${base.minor}.${latestPatch + 1}`;
   const label = config.cli.prereleaseLabel || "alpha";
-  const prefix = `${targetStable}-${label}.`;
-  const pattern = new RegExp(`^${prefix.replaceAll(".", "\\.")}(\\d+)$`);
-  const indexes = publishedVersions
-    .map((version) => version.match(pattern))
-    .filter(Boolean)
-    .map((match) => Number(match[1]));
-
-  if (!indexes.length) return `${prefix}0`;
-  return `${prefix}${Math.max(...indexes) + 1}`;
+  return `${targetStable}-${label}.0`;
 }
 
 function setPackageVersion(version) {

--- a/scripts/prepare_cli_publish_version.mjs
+++ b/scripts/prepare_cli_publish_version.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // Keeps npm CLI package versions aligned with the user-facing product version.
 // Dev publishes use the configured prerelease base, e.g. 0.12.0-alpha.N.
-// Stable publishes use the configured stable base, then patch-bump only if
-// that exact stable version is already published. This prevents the CLI from
-// continuing an old alpha line after the app version moves forward.
+// Stable publishes use the configured stable base exactly. npm versions are
+// immutable, so CI skips publish when that version already exists instead of
+// inventing patch releases for unrelated main-branch updates.
 
 import { execFileSync } from "node:child_process";
 import { readFileSync, appendFileSync } from "node:fs";
@@ -51,19 +51,6 @@ function npmView(spec, fallback) {
   }
 }
 
-function compareSemver(a, b) {
-  const [aCore] = a.split("-", 1);
-  const [bCore] = b.split("-", 1);
-  const aParts = aCore.split(".").map(Number);
-  const bParts = bCore.split(".").map(Number);
-  for (let index = 0; index < 3; index += 1) {
-    if (aParts[index] !== bParts[index]) {
-      return aParts[index] - bParts[index];
-    }
-  }
-  return 0;
-}
-
 function nextPrereleaseVersion(publishedAlpha) {
   const base = config.cli.prereleaseBase;
   const match = publishedAlpha.match(new RegExp(`^${base.replaceAll(".", "\\.")}\\.(\\d+)$`));
@@ -71,16 +58,6 @@ function nextPrereleaseVersion(publishedAlpha) {
     return config.cli.prereleaseSeed;
   }
   return `${base}.${Number(match[1]) + 1}`;
-}
-
-function nextStableVersion(latestStable) {
-  const stableBase = config.cli.stableBase;
-  if (compareSemver(stableBase, latestStable) > 0) {
-    return stableBase;
-  }
-
-  const [major, minor, patch] = latestStable.split(".").map(Number);
-  return `${major}.${minor}.${patch + 1}`;
 }
 
 function setPackageVersion(version) {
@@ -112,16 +89,16 @@ if (channel === "check") {
   if (!signupSource.includes(config.userFacing)) {
     fail(`signup version_title must include ${config.userFacing}`);
   }
-  if (cliPackage.version !== config.cli.prereleaseSeed) {
-    fail(`CLI package.json version must be ${config.cli.prereleaseSeed}, got ${cliPackage.version}`);
+  if (cliPackage.version !== config.cli.stableBase) {
+    fail(`CLI package.json version must be ${config.cli.stableBase}, got ${cliPackage.version}`);
   }
-  writeOutput(config.cli.prereleaseSeed);
+  writeOutput(config.cli.stableBase);
 } else if (channel === "dev") {
   const version = nextPrereleaseVersion(npmView("openmates@alpha", ""));
   setPackageVersion(version);
   writeOutput(version);
 } else if (channel === "main") {
-  const version = nextStableVersion(npmView("openmates", "0.0.0"));
+  const version = config.cli.stableBase;
   setPackageVersion(version);
   writeOutput(version);
 } else {

--- a/scripts/prepare_cli_publish_version.mjs
+++ b/scripts/prepare_cli_publish_version.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 // Keeps npm CLI package versions aligned with the user-facing product version.
-// Dev publishes use the configured prerelease base, e.g. 0.12.0-alpha.N.
-// Stable publishes use the configured stable base as a release line. If the
-// base already exists on npm, CI publishes the next patch in that line.
+// Stable publishes use the configured stable base as a release line. Dev
+// publishes use prereleases for the next stable patch in that same line.
 
 import { execFileSync } from "node:child_process";
 import { readFileSync, appendFileSync } from "node:fs";
@@ -37,19 +36,6 @@ function assertSemver(value, label) {
   }
 }
 
-function npmView(spec, fallback) {
-  const override = args.get(spec === "openmates@alpha" ? "published-alpha" : "latest-stable");
-  if (override !== undefined) {
-    return override;
-  }
-
-  try {
-    return execFileSync("npm", ["view", spec, "version"], { encoding: "utf8" }).trim();
-  } catch {
-    return fallback;
-  }
-}
-
 function npmVersions(fallback) {
   const override = args.get("published-versions");
   if (override !== undefined) {
@@ -71,15 +57,6 @@ function parseStableVersion(version) {
   return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
 }
 
-function nextPrereleaseVersion(publishedAlpha) {
-  const base = config.cli.prereleaseBase;
-  const match = publishedAlpha.match(new RegExp(`^${base.replaceAll(".", "\\.")}\\.(\\d+)$`));
-  if (!match) {
-    return config.cli.prereleaseSeed;
-  }
-  return `${base}.${Number(match[1]) + 1}`;
-}
-
 function nextStableVersion(publishedVersions) {
   const base = parseStableVersion(config.cli.stableBase);
   if (!base) {
@@ -93,6 +70,20 @@ function nextStableVersion(publishedVersions) {
 
   if (!patches.length) return config.cli.stableBase;
   return `${base.major}.${base.minor}.${Math.max(...patches) + 1}`;
+}
+
+function nextPrereleaseVersion(publishedVersions) {
+  const targetStable = nextStableVersion(publishedVersions);
+  const label = config.cli.prereleaseLabel || "alpha";
+  const prefix = `${targetStable}-${label}.`;
+  const pattern = new RegExp(`^${prefix.replaceAll(".", "\\.")}(\\d+)$`);
+  const indexes = publishedVersions
+    .map((version) => version.match(pattern))
+    .filter(Boolean)
+    .map((match) => Number(match[1]));
+
+  if (!indexes.length) return `${prefix}0`;
+  return `${prefix}${Math.max(...indexes) + 1}`;
 }
 
 function setPackageVersion(version) {
@@ -114,9 +105,8 @@ function writeOutput(version) {
 }
 
 assertSemver(config.cli.stableBase, "cli.stableBase");
-assertSemver(config.cli.prereleaseSeed, "cli.prereleaseSeed");
-if (!config.cli.prereleaseSeed.startsWith(`${config.cli.prereleaseBase}.`)) {
-  fail("cli.prereleaseSeed must start with cli.prereleaseBase plus a numeric suffix");
+if (!/^[0-9A-Za-z-]+$/.test(config.cli.prereleaseLabel || "alpha")) {
+  fail(`cli.prereleaseLabel must be a valid semver prerelease identifier, got ${config.cli.prereleaseLabel}`);
 }
 
 if (channel === "check") {
@@ -129,7 +119,7 @@ if (channel === "check") {
   }
   writeOutput(config.cli.stableBase);
 } else if (channel === "dev") {
-  const version = nextPrereleaseVersion(npmView("openmates@alpha", ""));
+  const version = nextPrereleaseVersion(npmVersions([]));
   setPackageVersion(version);
   writeOutput(version);
 } else if (channel === "main") {

--- a/scripts/prepare_cli_publish_version.mjs
+++ b/scripts/prepare_cli_publish_version.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 // Keeps npm CLI package versions aligned with the user-facing product version.
 // Dev publishes use the configured prerelease base, e.g. 0.12.0-alpha.N.
-// Stable publishes use the configured stable base exactly. npm versions are
-// immutable, so CI skips publish when that version already exists instead of
-// inventing patch releases for unrelated main-branch updates.
+// Stable publishes use the configured stable base as a release line. If the
+// base already exists on npm, CI publishes the next patch in that line.
 
 import { execFileSync } from "node:child_process";
 import { readFileSync, appendFileSync } from "node:fs";
@@ -51,6 +50,27 @@ function npmView(spec, fallback) {
   }
 }
 
+function npmVersions(fallback) {
+  const override = args.get("published-versions");
+  if (override !== undefined) {
+    return override.split(",").map((version) => version.trim()).filter(Boolean);
+  }
+
+  try {
+    const output = execFileSync("npm", ["view", "openmates", "versions", "--json"], { encoding: "utf8" }).trim();
+    const parsed = JSON.parse(output || "[]");
+    return Array.isArray(parsed) ? parsed.filter((version) => typeof version === "string") : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function parseStableVersion(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
 function nextPrereleaseVersion(publishedAlpha) {
   const base = config.cli.prereleaseBase;
   const match = publishedAlpha.match(new RegExp(`^${base.replaceAll(".", "\\.")}\\.(\\d+)$`));
@@ -58,6 +78,21 @@ function nextPrereleaseVersion(publishedAlpha) {
     return config.cli.prereleaseSeed;
   }
   return `${base}.${Number(match[1]) + 1}`;
+}
+
+function nextStableVersion(publishedVersions) {
+  const base = parseStableVersion(config.cli.stableBase);
+  if (!base) {
+    fail(`cli.stableBase must be a stable npm semver string, got ${config.cli.stableBase}`);
+  }
+
+  const patches = publishedVersions
+    .map(parseStableVersion)
+    .filter((version) => version && version.major === base.major && version.minor === base.minor && version.patch >= base.patch)
+    .map((version) => version.patch);
+
+  if (!patches.length) return config.cli.stableBase;
+  return `${base.major}.${base.minor}.${Math.max(...patches) + 1}`;
 }
 
 function setPackageVersion(version) {
@@ -98,7 +133,7 @@ if (channel === "check") {
   setPackageVersion(version);
   writeOutput(version);
 } else if (channel === "main") {
-  const version = config.cli.stableBase;
+  const version = nextStableVersion(npmVersions([]));
   setPackageVersion(version);
   writeOutput(version);
 } else {

--- a/scripts/prepare_python_publish_version.py
+++ b/scripts/prepare_python_publish_version.py
@@ -54,6 +54,31 @@ def parse_version_tuple(version: str) -> tuple[int, int, int]:
     return int(parts[0]), int(parts[1]), int(parts[2])
 
 
+def release_line_entries(config: dict, versions: list[str]) -> tuple[tuple[int, int, int], list[tuple[int, bool]]]:
+    major, minor, base_patch = parse_version_tuple(config["stableBase"])
+    label = config.get("prereleaseLabel", "a")
+    prerelease_pattern = re.compile(rf"^(\d+)\.(\d+)\.(\d+){re.escape(label)}\d+$")
+    entries: list[tuple[int, bool]] = []
+
+    for version in versions:
+        if SEMVER_PATTERN.match(version):
+            parsed_major, parsed_minor, patch = parse_version_tuple(version)
+            if parsed_major == major and parsed_minor == minor and patch >= base_patch:
+                entries.append((patch, True))
+            continue
+
+        match = prerelease_pattern.match(version)
+        if not match:
+            continue
+        parsed_major = int(match.group(1))
+        parsed_minor = int(match.group(2))
+        patch = int(match.group(3))
+        if parsed_major == major and parsed_minor == minor and patch >= base_patch:
+            entries.append((patch, False))
+
+    return (major, minor, base_patch), entries
+
+
 def published_versions(args: argparse.Namespace) -> list[str]:
     if args.published_versions is not None:
         return [version.strip() for version in args.published_versions.split(",") if version.strip()]
@@ -66,29 +91,22 @@ def published_versions(args: argparse.Namespace) -> list[str]:
 
 
 def next_prerelease_version(config: dict, versions: list[str]) -> str:
-    stable = next_stable_version(config, versions)
+    (major, minor, base_patch), entries = release_line_entries(config, versions)
+    latest_patch = max((patch for patch, _stable in entries), default=base_patch - 1)
+    stable = f"{major}.{minor}.{latest_patch + 1}"
     label = config.get("prereleaseLabel", "a")
-    base = f"{stable}{label}"
-    pattern = re.compile(rf"^{re.escape(base)}(\d+)$")
-    indexes = [int(match.group(1)) for version in versions if (match := pattern.match(version))]
-    if not indexes:
-        return f"{base}0"
-    return f"{base}{max(indexes) + 1}"
+    return f"{stable}{label}0"
 
 
 def next_stable_version(config: dict, versions: list[str]) -> str:
-    stable_base = config["stableBase"]
-    major, minor, base_patch = parse_version_tuple(stable_base)
-    patches = [
-        patch
-        for version in versions
-        if SEMVER_PATTERN.match(version)
-        for parsed_major, parsed_minor, patch in [parse_version_tuple(version)]
-        if parsed_major == major and parsed_minor == minor and patch >= base_patch
-    ]
-    if not patches:
-        return stable_base
-    return f"{major}.{minor}.{max(patches) + 1}"
+    (major, minor, _base_patch), entries = release_line_entries(config, versions)
+    if not entries:
+        return config["stableBase"]
+
+    latest_patch = max(patch for patch, _stable in entries)
+    latest_patch_is_stable = any(patch == latest_patch and stable for patch, stable in entries)
+    patch = latest_patch + 1 if latest_patch_is_stable else latest_patch
+    return f"{major}.{minor}.{patch}"
 
 
 def validate_config(config: dict) -> None:

--- a/scripts/prepare_python_publish_version.py
+++ b/scripts/prepare_python_publish_version.py
@@ -56,17 +56,6 @@ def parse_version_tuple(version: str) -> tuple[int, int, int]:
     return int(parts[0]), int(parts[1]), int(parts[2])
 
 
-def next_patch(version: str) -> str:
-    major, minor, patch = parse_version_tuple(version)
-    return f"{major}.{minor}.{patch + 1}"
-
-
-def compare_stable(left: str, right: str) -> int:
-    left_tuple = parse_version_tuple(left)
-    right_tuple = parse_version_tuple(right)
-    return (left_tuple > right_tuple) - (left_tuple < right_tuple)
-
-
 def published_versions(args: argparse.Namespace) -> list[str]:
     if args.published_versions is not None:
         return [version.strip() for version in args.published_versions.split(",") if version.strip()]
@@ -90,13 +79,17 @@ def next_prerelease_version(config: dict, versions: list[str]) -> str:
 
 def next_stable_version(config: dict, versions: list[str]) -> str:
     stable_base = config["stableBase"]
-    stable_versions = [version for version in versions if SEMVER_PATTERN.match(version)]
-    if stable_base not in stable_versions:
+    major, minor, base_patch = parse_version_tuple(stable_base)
+    patches = [
+        patch
+        for version in versions
+        if SEMVER_PATTERN.match(version)
+        for parsed_major, parsed_minor, patch in [parse_version_tuple(version)]
+        if parsed_major == major and parsed_minor == minor and patch >= base_patch
+    ]
+    if not patches:
         return stable_base
-    latest = max(stable_versions, key=parse_version_tuple) if stable_versions else "0.0.0"
-    if compare_stable(stable_base, latest) > 0:
-        return stable_base
-    return next_patch(latest)
+    return f"{major}.{minor}.{max(patches) + 1}"
 
 
 def validate_config(config: dict) -> None:

--- a/scripts/prepare_python_publish_version.py
+++ b/scripts/prepare_python_publish_version.py
@@ -25,8 +25,6 @@ PYPROJECT_PATH = ROOT / "packages" / "openmates-python" / "pyproject.toml"
 PYPI_JSON_URL = "https://pypi.org/pypi/openmates/json"
 VERSION_PATTERN = re.compile(r'^version = "([^"]+)"$', re.MULTILINE)
 SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
-PRERELEASE_PATTERN = re.compile(r"^\d+\.\d+\.\d+a\d+$")
-
 
 def fail(message: str) -> None:
     print(message, file=sys.stderr)
@@ -68,12 +66,13 @@ def published_versions(args: argparse.Namespace) -> list[str]:
 
 
 def next_prerelease_version(config: dict, versions: list[str]) -> str:
-    base = config["prereleaseBase"]
-    seed = config["prereleaseSeed"]
+    stable = next_stable_version(config, versions)
+    label = config.get("prereleaseLabel", "a")
+    base = f"{stable}{label}"
     pattern = re.compile(rf"^{re.escape(base)}(\d+)$")
     indexes = [int(match.group(1)) for version in versions if (match := pattern.match(version))]
     if not indexes:
-        return seed
+        return f"{base}0"
     return f"{base}{max(indexes) + 1}"
 
 
@@ -94,16 +93,11 @@ def next_stable_version(config: dict, versions: list[str]) -> str:
 
 def validate_config(config: dict) -> None:
     stable_base = config.get("stableBase", "")
-    prerelease_base = config.get("prereleaseBase", "")
-    prerelease_seed = config.get("prereleaseSeed", "")
+    prerelease_label = config.get("prereleaseLabel", "a")
     if not SEMVER_PATTERN.match(stable_base):
         fail(f"python.stableBase must be a PEP 440 stable version, got {stable_base}")
-    if not re.match(r"^\d+\.\d+\.\d+a$", prerelease_base):
-        fail(f"python.prereleaseBase must end in 'a', got {prerelease_base}")
-    if not PRERELEASE_PATTERN.match(prerelease_seed):
-        fail(f"python.prereleaseSeed must be a PEP 440 alpha version, got {prerelease_seed}")
-    if not prerelease_seed.startswith(prerelease_base):
-        fail("python.prereleaseSeed must start with python.prereleaseBase")
+    if prerelease_label != "a":
+        fail(f"python.prereleaseLabel must be 'a' for alpha prereleases, got {prerelease_label}")
 
 
 def main() -> None:

--- a/scripts/tests/test_prepare_python_publish_version.py
+++ b/scripts/tests/test_prepare_python_publish_version.py
@@ -26,16 +26,23 @@ def load_module():
 
 def test_next_prerelease_version_uses_seed_when_no_matching_release_exists():
     module = load_module()
-    config = {"prereleaseBase": "0.13.0a", "prereleaseSeed": "0.13.0a0"}
+    config = {"stableBase": "0.13.0", "prereleaseLabel": "a"}
 
     assert module.next_prerelease_version(config, ["0.12.0a9", "0.12.0"]) == "0.13.0a0"
 
 
 def test_next_prerelease_version_increments_latest_matching_alpha():
     module = load_module()
-    config = {"prereleaseBase": "0.13.0a", "prereleaseSeed": "0.13.0a0"}
+    config = {"stableBase": "0.13.0", "prereleaseLabel": "a"}
 
     assert module.next_prerelease_version(config, ["0.13.0a0", "0.13.0a3"]) == "0.13.0a4"
+
+
+def test_next_prerelease_version_targets_next_stable_patch_after_release():
+    module = load_module()
+    config = {"stableBase": "0.13.0", "prereleaseLabel": "a"}
+
+    assert module.next_prerelease_version(config, ["0.13.0", "0.13.1a0"]) == "0.13.1a1"
 
 
 def test_next_stable_version_uses_base_until_it_has_been_published():

--- a/scripts/tests/test_prepare_python_publish_version.py
+++ b/scripts/tests/test_prepare_python_publish_version.py
@@ -31,18 +31,18 @@ def test_next_prerelease_version_uses_seed_when_no_matching_release_exists():
     assert module.next_prerelease_version(config, ["0.12.0a9", "0.12.0"]) == "0.13.0a0"
 
 
-def test_next_prerelease_version_increments_latest_matching_alpha():
+def test_next_prerelease_version_uses_next_patch_slot_after_alpha():
     module = load_module()
     config = {"stableBase": "0.13.0", "prereleaseLabel": "a"}
 
-    assert module.next_prerelease_version(config, ["0.13.0a0", "0.13.0a3"]) == "0.13.0a4"
+    assert module.next_prerelease_version(config, ["0.13.0a0", "0.13.0a3"]) == "0.13.1a0"
 
 
 def test_next_prerelease_version_targets_next_stable_patch_after_release():
     module = load_module()
     config = {"stableBase": "0.13.0", "prereleaseLabel": "a"}
 
-    assert module.next_prerelease_version(config, ["0.13.0", "0.13.1a0"]) == "0.13.1a1"
+    assert module.next_prerelease_version(config, ["0.13.0", "0.13.1a0"]) == "0.13.2a0"
 
 
 def test_next_stable_version_uses_base_until_it_has_been_published():
@@ -57,6 +57,13 @@ def test_next_stable_version_patch_bumps_when_base_exists():
     config = {"stableBase": "0.13.0"}
 
     assert module.next_stable_version(config, ["0.13.0", "0.13.1"]) == "0.13.2"
+
+
+def test_next_stable_version_promotes_latest_prerelease_patch():
+    module = load_module()
+    config = {"stableBase": "0.13.0", "prereleaseLabel": "a"}
+
+    assert module.next_stable_version(config, ["0.13.0", "0.13.1a0"]) == "0.13.1"
 
 
 def test_next_stable_version_stays_within_configured_release_line():

--- a/scripts/tests/test_prepare_python_publish_version.py
+++ b/scripts/tests/test_prepare_python_publish_version.py
@@ -50,3 +50,10 @@ def test_next_stable_version_patch_bumps_when_base_exists():
     config = {"stableBase": "0.13.0"}
 
     assert module.next_stable_version(config, ["0.13.0", "0.13.1"]) == "0.13.2"
+
+
+def test_next_stable_version_stays_within_configured_release_line():
+    module = load_module()
+    config = {"stableBase": "0.13.0"}
+
+    assert module.next_stable_version(config, ["0.13.0", "0.13.1", "0.14.0"]) == "0.13.2"

--- a/shared/config/product_version.json
+++ b/shared/config/product_version.json
@@ -1,5 +1,5 @@
 {
-  "userFacing": "v0.14.0",
+  "userFacing": "v0.14",
   "cli": {
     "stableBase": "0.14.0",
     "prereleaseBase": "0.14.0-alpha",

--- a/shared/config/product_version.json
+++ b/shared/config/product_version.json
@@ -2,12 +2,10 @@
   "userFacing": "v0.14",
   "cli": {
     "stableBase": "0.14.0",
-    "prereleaseBase": "0.14.0-alpha",
-    "prereleaseSeed": "0.14.0-alpha.0"
+    "prereleaseLabel": "alpha"
   },
   "python": {
     "stableBase": "0.14.0",
-    "prereleaseBase": "0.14.0a",
-    "prereleaseSeed": "0.14.0a0"
+    "prereleaseLabel": "a"
   }
 }


### PR DESCRIPTION
## Summary
This PR prepares the v0.14 release line for package publishing across npm, PyPI, and self-host images while improving package documentation for developers. It also restores and preserves authenticated header actions, and adds package listing links to the settings footer so users can discover the CLI and SDK packages from the app.

## Features
- Add npm and PyPI package listing links to the settings footer developer section.
- Link the canonical SDK documentation page from the sitemap and generated docs surface.

## Bug Fixes
- Restore authenticated header actions for the GitHub link and referral/free-credits CTA.
- Keep authenticated header actions visible when the settings menu is open, with account preflight coverage for the open-settings state.

## Other Changes
- Rewrite and simplify the npm CLI README with install, pair-auth, chat/app/settings usage, self-host management, environment targeting, SDK usage, and release-line guidance.
- Improve the Python SDK PyPI README with install, API key setup, quick starts, active namespaces, error guidance, release-line versioning, and package branding/project URLs.
- Align npm and PyPI prerelease/stable publishing around product release lines and patch slots for v0.14.x.
- Ensure main pushes publish stable CLI releases only when the configured version is missing.
- Add optional Discord notifications for self-host image publishing and keep optional PR comments best-effort so notification permission issues do not fail successful image publishes.
- Update related release, deployment, package, SEO, and mirrored skill documentation.