### PR TITLE
fix: load encrypted chats on Apple Watch

### DIFF
--- a/backend/core/api/app/routes/chats.py
+++ b/backend/core/api/app/routes/chats.py
@@ -1,0 +1,84 @@
+"""Session-authenticated encrypted chat reads for first-party clients.
+
+The routes expose only the encrypted metadata required by native chat lists and
+threads. They reuse cookie authentication and Directus ownership checks, never
+decrypt content server-side, and return the same 404 for missing or foreign
+chats to avoid existence disclosure.
+"""
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from backend.core.api.app.routes.auth_routes.auth_dependencies import get_current_user
+from backend.core.api.app.models.user import User
+
+
+router = APIRouter(prefix="/v1", tags=["Chats"])
+NATIVE_CHAT_SORT = "-pinned,-last_edited_overall_timestamp"
+
+
+def _string_timestamp(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _watch_chat_payload(chat: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": chat.get("id"),
+        "encrypted_title": chat.get("encrypted_title"),
+        "encrypted_chat_summary": chat.get("encrypted_chat_summary"),
+        "encrypted_chat_key": chat.get("encrypted_chat_key"),
+        "pinned": chat.get("pinned", False),
+        "updated_at": _string_timestamp(chat.get("updated_at")),
+        "last_message_at": _string_timestamp(chat.get("last_message_timestamp")),
+    }
+
+
+def _watch_message_payload(message: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": message.get("id") or message.get("client_message_id"),
+        "chat_id": message.get("chat_id"),
+        "role": message.get("role"),
+        "encrypted_content": message.get("encrypted_content"),
+        "created_at": _string_timestamp(message.get("created_at")) or "",
+    }
+
+
+def _message_record(message: str | dict[str, Any]) -> dict[str, Any] | None:
+    if isinstance(message, dict):
+        return message
+    try:
+        decoded = json.loads(message)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+@router.get("/chats")
+async def list_chats(
+    request: Request,
+    limit: int = Query(default=20, ge=1, le=100),
+    current_user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    chats = await request.app.state.directus_service.chat.get_user_chats_metadata(
+        current_user.id,
+        limit=limit,
+        offset=0,
+        sort=NATIVE_CHAT_SORT,
+    )
+    return {"chats": [_watch_chat_payload(chat) for chat in chats], "limit": limit}
+
+
+@router.get("/chats/{chat_id}/messages")
+async def list_chat_messages(
+    chat_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+) -> list[dict[str, Any]]:
+    chat_service = request.app.state.directus_service.chat
+    if not await chat_service.check_chat_ownership(chat_id, current_user.id):
+        raise HTTPException(status_code=404, detail="Chat not found")
+    messages = await chat_service.get_all_messages_for_chat(chat_id, decrypt_content=False)
+    records = [_message_record(message) for message in messages or []]
+    return [_watch_message_payload(record) for record in records if record is not None]

--- a/backend/core/api/app/services/directus/chat_methods.py
+++ b/backend/core/api/app/services/directus/chat_methods.py
@@ -402,7 +402,13 @@ class ChatMethods:
             logger.error(f"Error checking chat ownership for chat {chat_id}, user {user_id}: {e}", exc_info=True)
             return False
 
-    async def get_user_chats_metadata(self, user_id: str, limit: int = 100, offset: int = 0) -> List[Dict[str, Any]]:
+    async def get_user_chats_metadata(
+        self,
+        user_id: str,
+        limit: int = 100,
+        offset: int = 0,
+        sort: str = "-pinned,-updated_at",
+    ) -> List[Dict[str, Any]]:
         """
         Fetches metadata for all chats belonging to a user from Directus, excluding content.
         Uses hashed_user_id for filtering (privacy by design - raw user_id is never stored in Directus).
@@ -415,7 +421,7 @@ class ChatMethods:
             'fields': CHAT_METADATA_FIELDS,
             'limit': limit,
             'offset': offset,
-            'sort': '-pinned,-updated_at'
+            'sort': sort
         }
         try:
             response = await self.directus_service.get_items('chats', params=params)

--- a/backend/core/api/main.py
+++ b/backend/core/api/main.py
@@ -32,7 +32,7 @@ import httpx  # noqa: E402 # Used for CMS readiness check during lifespan startu
 from typing import Dict, Optional  # noqa: E402 # For type hinting
 
 # Make sure the path is correct based on your project structure
-from backend.core.api.app.routes import auth, email, invoice, credit_note, settings, payments, referrals, websockets, sdk  # noqa: E402
+from backend.core.api.app.routes import auth, chats, email, invoice, credit_note, settings, payments, referrals, websockets, sdk  # noqa: E402
 from backend.core.api.app.routes import anonymous  # noqa: E402 # Anonymous free usage routes
 from backend.core.api.app.routes import internal_api  # noqa: E402 # Import the new internal API router
 from backend.core.api.app.routes import apps  # noqa: E402 # Import apps router
@@ -1329,6 +1329,7 @@ def create_app() -> FastAPI:
     
     # Web app only routers - excluded from API schema (use web app auth, not API keys)
     app.include_router(websockets.router, include_in_schema=False)  # WebSocket endpoints - web app only
+    app.include_router(chats.router, include_in_schema=False)  # Encrypted chat reads - session-authenticated first-party clients
     app.include_router(internal_api.router, include_in_schema=False)  # Internal API router - service-to-service communication only
     app.include_router(apps.router, include_in_schema=False)  # Apps router - public endpoint, not API key based
     app.include_router(code_execution.router, include_in_schema=False)  # Code Run sandbox execution - web app only

--- a/backend/tests/test_native_chats_api.py
+++ b/backend/tests/test_native_chats_api.py
@@ -1,0 +1,127 @@
+"""Contract tests for session-authenticated native chat reads.
+
+These tests keep encrypted chat metadata opaque, verify ownership before message
+reads, and inspect FastAPI dependencies without requiring a live Directus or
+authenticated user account. The same routes serve independent Apple clients.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from backend.core.api.app.routes.auth_routes.auth_dependencies import get_current_user
+from backend.core.api.app.routes.chats import _message_record, list_chat_messages, list_chats, router
+
+
+def _request(chat_service):
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(directus_service=SimpleNamespace(chat=chat_service))))
+
+
+def test_native_chat_routes_require_session_authentication() -> None:
+    routes = {route.path: route for route in router.routes}
+
+    assert routes["/v1/chats"].methods == {"GET"}
+    assert routes["/v1/chats/{chat_id}/messages"].methods == {"GET"}
+    for path in ("/v1/chats", "/v1/chats/{chat_id}/messages"):
+        dependency_calls = [dependency.call for dependency in routes[path].dependant.dependencies]
+        assert get_current_user in dependency_calls
+
+
+def test_message_record_rejects_malformed_directus_json() -> None:
+    assert _message_record("not-json") is None
+    assert _message_record("[]") is None
+
+
+@pytest.mark.asyncio
+async def test_list_chats_returns_bounded_encrypted_metadata() -> None:
+    chat_service = SimpleNamespace(
+        get_user_chats_metadata=AsyncMock(return_value=[
+            {
+                "id": "chat-owned",
+                "encrypted_title": "cipher-title",
+                "encrypted_chat_summary": "cipher-summary",
+                "encrypted_chat_key": "wrapped-chat-key",
+                "pinned": False,
+                "updated_at": 200,
+                "last_message_timestamp": 190,
+            }
+        ])
+    )
+
+    result = await list_chats(
+        request=_request(chat_service),
+        limit=20,
+        current_user=SimpleNamespace(id="user-1"),
+    )
+
+    assert result == {
+        "chats": [
+            {
+                "id": "chat-owned",
+                "encrypted_title": "cipher-title",
+                "encrypted_chat_summary": "cipher-summary",
+                "encrypted_chat_key": "wrapped-chat-key",
+                "pinned": False,
+                "updated_at": "200",
+                "last_message_at": "190",
+            }
+        ],
+        "limit": 20,
+    }
+    chat_service.get_user_chats_metadata.assert_awaited_once_with(
+        "user-1",
+        limit=20,
+        offset=0,
+        sort="-pinned,-last_edited_overall_timestamp",
+    )
+    assert "title" not in result["chats"][0]
+    assert "chat_summary" not in result["chats"][0]
+
+
+@pytest.mark.asyncio
+async def test_list_chat_messages_requires_ownership_before_encrypted_read() -> None:
+    chat_service = SimpleNamespace(
+        check_chat_ownership=AsyncMock(return_value=True),
+        get_all_messages_for_chat=AsyncMock(return_value=[
+            json.dumps({
+                "id": "message-1",
+                "chat_id": "chat-owned",
+                "role": "assistant",
+                "encrypted_content": "cipher-message",
+                "created_at": 201,
+            })
+        ]),
+    )
+
+    result = await list_chat_messages(
+        chat_id="chat-owned",
+        request=_request(chat_service),
+        current_user=SimpleNamespace(id="user-1"),
+    )
+
+    assert result[0]["encrypted_content"] == "cipher-message"
+    assert "content" not in result[0]
+    chat_service.check_chat_ownership.assert_awaited_once_with("chat-owned", "user-1")
+    chat_service.get_all_messages_for_chat.assert_awaited_once_with("chat-owned", decrypt_content=False)
+
+
+@pytest.mark.asyncio
+async def test_list_chat_messages_hides_cross_user_chat_existence() -> None:
+    chat_service = SimpleNamespace(
+        check_chat_ownership=AsyncMock(return_value=False),
+        get_all_messages_for_chat=AsyncMock(),
+    )
+
+    with pytest.raises(HTTPException) as error:
+        await list_chat_messages(
+            chat_id="chat-other-user",
+            request=_request(chat_service),
+            current_user=SimpleNamespace(id="user-1"),
+        )
+
+    assert error.value.status_code == 404
+    assert error.value.detail == "Chat not found"
+    chat_service.get_all_messages_for_chat.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add session-authenticated encrypted chat list and message routes
- validate chat ownership before message reads and hide cross-user existence
- normalize Directus encrypted message JSON and match native chat ordering

## Verification
- `/home/superdev/projects/OpenMates/.venv/bin/python3 -m pytest backend/tests/test_native_chats_api.py` (5 passed)
- Watch runtime tests: 10 passed
- Watch auth persistence tests: 2 passed
- Watch build and 60-second startup verification passed

## Scope
This is an isolated production hotfix with four backend files. It excludes unrelated `dev` work.