### PR TITLE
Hotfix: production chat metadata and image processing

### DIFF
--- a/.github/workflows/publish-selfhost-images.yml
+++ b/.github/workflows/publish-selfhost-images.yml
@@ -113,6 +113,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Generate API email locales
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @repo/ui build:translations
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/backend/apps/ai/llm_providers/bedrock_shared.py
+++ b/backend/apps/ai/llm_providers/bedrock_shared.py
@@ -118,7 +118,7 @@ def convert_messages_to_converse_format(
         if role == "tool":
             tool_call_id = msg.get("tool_call_id", "")
             tool_content = _convert_tool_result_content(content)
-            converse_messages.append({
+            tool_result_message = {
                 "role": "user",
                 "content": [{
                     "toolResult": {
@@ -126,7 +126,15 @@ def convert_messages_to_converse_format(
                         "content": tool_content,
                     }
                 }]
-            })
+            }
+            # Converse requires every result for an assistant's parallel tool
+            # calls in the immediately following user turn (including images).
+            if converse_messages and converse_messages[-1]["role"] == "user" and any(
+                "toolResult" in block for block in converse_messages[-1]["content"]
+            ):
+                converse_messages[-1]["content"].extend(tool_result_message["content"])
+            else:
+                converse_messages.append(tool_result_message)
             continue
 
         # Handle assistant messages with tool calls

--- a/backend/core/api/Dockerfile.selfhost
+++ b/backend/core/api/Dockerfile.selfhost
@@ -47,6 +47,7 @@ RUN test -s /shared/config/pricing.yml && test -s /shared/config/urls.yml
 COPY frontend/apps/web_app/static/favicon.png /app/frontend/apps/web_app/static/favicon.png
 COPY frontend/packages/ui/src/i18n /app/frontend/packages/ui/src/i18n
 COPY frontend/apps/web_app/static/newsletter-assets /app/frontend/apps/web_app/static/newsletter-assets
+RUN test -s /app/frontend/packages/ui/src/i18n/locales/en.json
 
 RUN mkdir -p /app/logs /app/backend/core/api/logs /celerybeat-data \
     && chmod -R 777 /app/logs /app/backend/core/api/logs \

--- a/backend/core/api/app/services/s3/service.py
+++ b/backend/core/api/app/services/s3/service.py
@@ -59,6 +59,7 @@ logger = logging.getLogger(__name__)
 HETZNER_OBJECT_STORAGE_PROVIDER = "Hetzner Object Storage"
 EXTERNAL_PROVIDER_DEGRADED = "external_provider_degraded"
 INTERNAL_STORAGE_CONFIGURATION = "internal_storage_configuration"
+BUCKET_CREATION_SETTLE_SECONDS = 2
 def _stream_sha256(body: Any) -> str:
     digest = hashlib.sha256()
     try:
@@ -378,8 +379,22 @@ class S3UploadService:
         """Reconcile remote bucket policy without making service startup depend on it."""
         if not self.configured or self.client is None:
             return
-        await self._initialize_buckets()
-        await self._reconcile_regional_bucket_policies()
+        reconciliation_failed = False
+        for label, reconcile in (
+            ("active-region buckets", self._initialize_buckets),
+            ("regional bucket policies", self._reconcile_regional_bucket_policies),
+        ):
+            try:
+                await reconcile()
+            except Exception as exc:
+                logger.warning(
+                    "Object storage reconciliation step failed: step=%s error=%s",
+                    label,
+                    type(exc).__name__,
+                )
+                reconciliation_failed = True
+        if reconciliation_failed:
+            raise RuntimeError("object_storage_reconciliation_failed")
 
     async def check_availability(self) -> str:
         """Run one bounded, non-mutating provider probe and return a sanitized state."""
@@ -433,7 +448,7 @@ class S3UploadService:
                         logger.info("Created active-region bucket: logical_bucket=%s", bucket_key)
                         # Hetzner Object Storage can be briefly eventually consistent after bucket creation.
                         # Wait before applying ACL/lifecycle so first-start initialization does not fail noisily.
-                        await asyncio.sleep(2)
+                        await asyncio.sleep(BUCKET_CREATION_SETTLE_SECONDS)
                         bucket_exists = True
                     except ClientError as create_e:
                         logger.error("Failed to create active-region bucket: logical_bucket=%s error=%s", bucket_key, type(create_e).__name__)
@@ -461,7 +476,7 @@ class S3UploadService:
                         ACL=desired_acl,
                     )
                     logger.info("Reconciled active-region bucket ACL: logical_bucket=%s acl=%s", bucket_key, desired_acl)
-                except ClientError as acl_e:
+                except (ClientError, *_TRANSIENT_NETWORK_ERRORS) as acl_e:
                     logger.warning(
                         "Failed to reconcile active-region bucket ACL: logical_bucket=%s acl=%s error=%s",
                         bucket_key,
@@ -489,7 +504,10 @@ class S3UploadService:
             regional_configs = {}
             cors_buckets = []
             for bucket_key, bucket_config in BUCKETS.items():
-                if not bucket_config.get('managed', True):
+                if (
+                    not bucket_config.get('managed', True)
+                    or not should_replicate_bucket(bucket_key)
+                ):
                     continue
                 legacy_name = bucket_config[environment_name]
                 bucket_name = resolve_regional_bucket_name(legacy_name, region)
@@ -498,16 +516,37 @@ class S3UploadService:
                 except ClientError as exc:
                     error_code = str(exc.response.get('Error', {}).get('Code', ''))
                     if error_code in {'404', 'NoSuchBucket'}:
-                        logger.warning("Regional bucket is not provisioned: region=%s logical_bucket=%s", region, bucket_key)
+                        logger.info(
+                            "Regional bucket is missing; creating: region=%s logical_bucket=%s",
+                            region,
+                            bucket_key,
+                        )
+                        try:
+                            await asyncio.to_thread(client.create_bucket, Bucket=bucket_name)
+                            await asyncio.sleep(BUCKET_CREATION_SETTLE_SECONDS)
+                            logger.info(
+                                "Created regional bucket: region=%s logical_bucket=%s",
+                                region,
+                                bucket_key,
+                            )
+                        except (ClientError, *_TRANSIENT_NETWORK_ERRORS) as create_exc:
+                            logger.error(
+                                "Cannot create regional bucket: region=%s logical_bucket=%s error=%s",
+                                region,
+                                bucket_key,
+                                type(create_exc).__name__,
+                            )
+                            reconciliation_failed = True
+                            continue
+                    else:
+                        logger.error(
+                            "Cannot inspect regional bucket policy: region=%s logical_bucket=%s error=%s",
+                            region,
+                            bucket_key,
+                            error_code,
+                        )
+                        reconciliation_failed = True
                         continue
-                    logger.error(
-                        "Cannot inspect regional bucket policy: region=%s logical_bucket=%s error=%s",
-                        region,
-                        bucket_key,
-                        error_code,
-                    )
-                    reconciliation_failed = True
-                    continue
                 except _TRANSIENT_NETWORK_ERRORS as exc:
                     logger.warning(
                         "Regional bucket inspection is degraded: region=%s logical_bucket=%s error=%s",
@@ -521,12 +560,16 @@ class S3UploadService:
                 desired_acl = 'public-read' if bucket_config.get('access') == 'public-read' else 'private'
                 try:
                     await asyncio.to_thread(client.put_bucket_acl, Bucket=bucket_name, ACL=desired_acl)
-                except ClientError as exc:
+                except (ClientError, *_TRANSIENT_NETWORK_ERRORS) as exc:
                     logger.error(
                         "Cannot reconcile regional bucket ACL: region=%s logical_bucket=%s error=%s",
                         region,
                         bucket_key,
-                        str(exc.response.get('Error', {}).get('Code', 'unknown')),
+                        (
+                            str(exc.response.get('Error', {}).get('Code', 'unknown'))
+                            if isinstance(exc, ClientError)
+                            else type(exc).__name__
+                        ),
                     )
                     reconciliation_failed = True
                     continue

--- a/backend/tests/test_bedrock_image_multimodal.py
+++ b/backend/tests/test_bedrock_image_multimodal.py
@@ -150,6 +150,35 @@ def test_bedrock_image_conversion_decodes_data_url_to_raw_bytes() -> None:
     assert image["source"]["bytes"] == image_bytes
 
 
+def test_bedrock_groups_parallel_image_results_in_the_next_user_turn() -> None:
+    if convert_messages_to_converse_format is None:
+        pytest.skip("Bedrock dependencies not installed locally (botocore)")
+
+    image_bytes = b"\x89PNG\r\n\x1a\nimage"
+    data_url = "data:image/png;base64," + base64.b64encode(image_bytes).decode("ascii")
+    calls = [
+        {"id": tool_id, "function": {"name": "images_view", "arguments": "{}"}}
+        for tool_id in ("image-1", "image-2")
+    ]
+    history = [{"role": "user", "content": "Compare these images"},
+               {"role": "assistant", "tool_calls": calls}]
+    history.extend({"role": "tool", "tool_call_id": call["id"], "content": [
+        {"type": "text", "text": call["id"]},
+        {"type": "image_url", "image_url": {"url": data_url}},
+    ]} for call in calls)
+    history.extend([{"role": "assistant", "content": "Comparison"},
+                    {"role": "user", "content": "Thanks"}])
+
+    _, messages = convert_messages_to_converse_format(history)
+
+    assert [message["role"] for message in messages] == [
+        "user", "assistant", "user", "assistant", "user"
+    ]
+    results = [block["toolResult"] for block in messages[2]["content"]]
+    assert [result["toolUseId"] for result in results] == ["image-1", "image-2"]
+    assert all(result["content"][1]["image"]["source"]["bytes"] == image_bytes for result in results)
+
+
 def test_bedrock_named_openai_tool_choice_uses_converse_tool_name() -> None:
     if convert_tool_choice_to_converse_format is None:
         pytest.skip("Bedrock dependencies not installed locally (botocore)")

--- a/backend/tests/test_s3_multi_region_service.py
+++ b/backend/tests/test_s3_multi_region_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import importlib
 
 import pytest
+from botocore.exceptions import ClientError
 
 from backend.tests.s3_service_test_support import load_s3_service_module
 
@@ -150,6 +151,23 @@ class ExistingBucketClient:
         self.acls.append((Bucket, ACL))
 
 
+class MissingRegionalBucketClient(ExistingBucketClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.created_buckets = []
+
+    def head_bucket(self, *, Bucket):
+        self.head_buckets.append(Bucket)
+        if Bucket not in self.created_buckets:
+            raise ClientError(
+                {"Error": {"Code": "NoSuchBucket", "Message": "missing"}},
+                "HeadBucket",
+            )
+
+    def create_bucket(self, *, Bucket):
+        self.created_buckets.append(Bucket)
+
+
 class ExternalUploadClient:
     def head_object(self, *, Bucket, Key):
         return {"Metadata": {"openmates-sha256": "a" * 64}}
@@ -228,6 +246,7 @@ async def test_existing_regional_buckets_receive_acl_lifecycle_and_cors(monkeypa
     }
     monkeypatch.setattr(service_module, "BUCKETS", {"chatfiles": bucket_config})
     monkeypatch.setattr(service_module, "CORS_ENABLED_BUCKETS", ["dev-openmates-chatfiles"])
+    monkeypatch.setattr(service_module, "BUCKET_CREATION_SETTLE_SECONDS", 0)
     lifecycle_calls = []
     cors_calls = []
     monkeypatch.setattr(
@@ -259,3 +278,84 @@ async def test_existing_regional_buckets_receive_acl_lifecycle_and_cors(monkeypa
         ["dev-openmates-chatfiles"],
         ["dev-openmates-chatfiles-fsn1"],
     ]
+
+
+# contract-test: direct surface=rest_api assertions=storage.regions.configurable-redundancy,storage.integrity.observable-reconcilable
+@pytest.mark.asyncio
+async def test_missing_managed_replica_is_created_once_and_exclusions_are_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service_module = load_s3_service_module()
+    bucket_config = {
+        "name": "openmates-chatfiles",
+        "dev_name": "dev-openmates-chatfiles",
+        "access": "private",
+        "lifecycle_policy": 30,
+    }
+    excluded_config = {
+        "name": "openmates-buffer-media",
+        "dev_name": "dev-openmates-buffer-media",
+        "access": "private",
+        "lifecycle_policy": 2,
+    }
+    unmanaged_config = {
+        "name": "openmates-retired",
+        "dev_name": "dev-openmates-retired",
+        "access": "private",
+        "managed": False,
+    }
+    monkeypatch.setattr(
+        service_module,
+        "BUCKETS",
+        {
+            "chatfiles": bucket_config,
+            "buffer_media": excluded_config,
+            "retired": unmanaged_config,
+        },
+    )
+    monkeypatch.setattr(service_module, "CORS_ENABLED_BUCKETS", ["dev-openmates-chatfiles"])
+    monkeypatch.setattr(service_module, "apply_lifecycle_policies", lambda *_args: None)
+    monkeypatch.setattr(service_module, "apply_cors_settings", lambda *_args: None)
+    client = MissingRegionalBucketClient()
+    service = service_module.S3UploadService(FakeSecretsManager())
+    service.environment = "development"
+    service.region_clients = {"fsn1": client}
+
+    await service._reconcile_regional_bucket_policies()
+    await service._reconcile_regional_bucket_policies()
+
+    assert client.created_buckets == ["dev-openmates-chatfiles-fsn1"]
+    assert client.head_buckets == [
+        "dev-openmates-chatfiles-fsn1",
+        "dev-openmates-chatfiles-fsn1",
+    ]
+    assert client.acls == [
+        ("dev-openmates-chatfiles-fsn1", "private"),
+        ("dev-openmates-chatfiles-fsn1", "private"),
+    ]
+
+
+# contract-test: direct surface=rest_api assertions=storage.integrity.observable-reconcilable,storage-resilience.core.s3-is-noncritical
+@pytest.mark.asyncio
+async def test_active_region_failure_does_not_skip_replica_reconciliation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service_module = load_s3_service_module()
+    service = service_module.S3UploadService(FakeSecretsManager())
+    service.configured = True
+    service.client = object()
+    regional_calls = []
+
+    async def fail_active_region() -> None:
+        raise service_module.ReadTimeoutError(endpoint_url="https://storage.invalid")
+
+    async def reconcile_replicas() -> None:
+        regional_calls.append(True)
+
+    monkeypatch.setattr(service, "_initialize_buckets", fail_active_region)
+    monkeypatch.setattr(service, "_reconcile_regional_bucket_policies", reconcile_replicas)
+
+    with pytest.raises(RuntimeError, match="object_storage_reconciliation_failed"):
+        await service.reconcile_configuration()
+
+    assert regional_calls == [True]

--- a/backend/tests/test_s3_service_no_sync_boto3_in_async.py
+++ b/backend/tests/test_s3_service_no_sync_boto3_in_async.py
@@ -244,6 +244,7 @@ def test_known_async_methods_are_covered():
         "_initialize_buckets",
         "_reconcile_regional_bucket_policies",
         "_persist_replication_outbox",
+        "persist_external_upload_replication",
         "upload_file",
         "upload_temporary_file",
         "upload_file_stream",

--- a/frontend/apps/web_app/tests/audio-recording-and-speech.spec.ts
+++ b/frontend/apps/web_app/tests/audio-recording-and-speech.spec.ts
@@ -256,9 +256,19 @@ test.describe.serial('Audio recording and assistant speech', () => {
 		expect(speakBox!.x + speakBox!.width).toBeLessThanOrEqual(messageBox!.x + messageBox!.width);
 		const chatId = page.url().match(/chat-id=([a-zA-Z0-9-]+)/)?.[1] ?? '';
 		expect(chatId, 'voice-first chat should become durable after its first message').toBeTruthy();
+		const initialHeaderTitle = page.getByTestId('chat-header-title');
+		await expect(initialHeaderTitle).toBeVisible({ timeout: 30_000 });
+		await expect(initialHeaderTitle).not.toContainText(/untitled|creating new chat/i);
+		await expect(page.getByTestId('chat-header-icon')).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByTestId('chat-header-summary')).not.toHaveText('', { timeout: 30_000 });
 
 		await page.reload({ waitUntil: 'domcontentloaded' });
 		await expect(page.getByTestId('message-assistant').last()).toBeVisible({ timeout: 60_000 });
+		const reloadedHeaderTitle = page.getByTestId('chat-header-title');
+		await expect(reloadedHeaderTitle).toBeVisible({ timeout: 30_000 });
+		await expect(reloadedHeaderTitle).not.toContainText(/untitled|creating new chat/i);
+		await expect(page.getByTestId('chat-header-icon')).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByTestId('chat-header-summary')).not.toHaveText('', { timeout: 30_000 });
 		const reloadedRecording = page.locator(`[data-message-id="${pendingMessageId}"]`).getByTestId('recording-preview');
 		await expect(reloadedRecording).toHaveAttribute('data-transcript', 'available');
 		await expect(reloadedRecording).toHaveAttribute('data-recording-title', TRANSCRIPTION_TITLE);

--- a/frontend/apps/web_app/tests/chat-flow.spec.ts
+++ b/frontend/apps/web_app/tests/chat-flow.spec.ts
@@ -1121,6 +1121,11 @@ test('logs in and sends a chat message', async ({ page }: { page: any }, testInf
 	// Wait for the chat messages to render (key derivation + sync after reload)
 	const userMsgAfterReload = page.getByTestId('message-user').first();
 	await expect(userMsgAfterReload).toBeVisible({ timeout: 30000 });
+	const reloadedHeaderTitle = page.getByTestId('chat-header-title');
+	await expect(reloadedHeaderTitle).toBeVisible({ timeout: 30000 });
+	await expect(reloadedHeaderTitle).not.toContainText(/untitled|creating new chat/i);
+	await expect(page.getByTestId('chat-header-icon')).toBeVisible({ timeout: 30000 });
+	await expect(page.getByTestId('chat-header-summary')).not.toHaveText('', { timeout: 30000 });
 
 	logChatCheckpoint('Verifying chat after tab reload...');
 	// Re-assert full decryption health

--- a/frontend/packages/ui/src/components/ActiveChat.svelte
+++ b/frontend/packages/ui/src/components/ActiveChat.svelte
@@ -4056,7 +4056,10 @@ console.debug('[ActiveChat] Loading child website embeds for web search fullscre
             return;
         }
 
-        if (resumeChatData && !isChatInActiveTeamContext(resumeChatData, contextTeamId)) {
+        // The loader below writes resumeChatData. Reading it as a tracked value
+        // here would make that write retrigger this effect indefinitely.
+        const currentResumeChat = untrack(() => resumeChatData);
+        if (currentResumeChat && !isChatInActiveTeamContext(currentResumeChat, contextTeamId)) {
             clearResumeChatCard();
         }
 

--- a/frontend/packages/ui/src/components/__tests__/activeChatResumeEffect.test.ts
+++ b/frontend/packages/ui/src/components/__tests__/activeChatResumeEffect.test.ts
@@ -1,0 +1,22 @@
+// Regression guard for the authenticated welcome-screen resume-card effect.
+// The effect invokes an async loader that writes resumeChatData after reading
+// IndexedDB. Its context-safety read must remain untracked, otherwise each
+// successful load schedules the effect again and creates an unbounded loop.
+// Deployed flow coverage verifies the resulting user-visible behavior.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../ActiveChat.svelte", import.meta.url), "utf8");
+
+describe("ActiveChat resume-card effect", () => {
+  // contract-test: direct surface=gui.web assertions=chats.local-state.precedence,sync.startup.bounded-phases
+  it("does not track the resume state that its async loader writes", () => {
+    expect(source).toContain(
+      "const currentResumeChat = untrack(() => resumeChatData);",
+    );
+    expect(source).toContain(
+      "if (currentResumeChat && !isChatInActiveTeamContext(currentResumeChat, contextTeamId))",
+    );
+  });
+});

--- a/frontend/packages/ui/src/services/__tests__/chatSyncServiceHandlersAI.test.ts
+++ b/frontend/packages/ui/src/services/__tests__/chatSyncServiceHandlersAI.test.ts
@@ -739,6 +739,69 @@ describe("handlePostProcessingCompletedImpl", () => {
       "encrypted-chat-key",
     );
   });
+
+  // contract-test: direct surface=gui.web assertions=chats.persistence.client-encrypted,chats.local-state.precedence,assistant-speech.preference.chat-scoped-default-off
+  it("keeps a generated summary when only the speech preference advanced metadata", async () => {
+    const existingChat = {
+      chat_id: "chat-1",
+      encrypted_title: "encrypted-title",
+      encrypted_chat_summary: null,
+      encrypted_auto_speak_response: "encrypted:true",
+      encrypted_chat_key: "encrypted-chat-key",
+      messages_v: 2,
+      title_v: 3,
+      metadata_v: 4,
+      last_edited_overall_timestamp: 100,
+      unread_count: 0,
+      created_at: 100,
+      updated_at: 200,
+    };
+    mockChatDB.getChat.mockResolvedValue(existingChat);
+    const service = {
+      dispatchEvent: vi.fn(),
+    } as unknown as ChatSynchronizationService;
+
+    await handlePostProcessingCompletedImpl(service, {
+      chat_id: "chat-1",
+      task_id: "task-1",
+      follow_up_request_suggestions: [],
+      new_chat_request_suggestions: [],
+      chat_summary: "Generated summary from the completed response",
+      share_cta_text: "",
+      chat_tags: [],
+      harmful_response: 0,
+      top_recommended_apps_for_user: [],
+      quick_tip_slugs: [],
+      source_title_v: 3,
+      source_metadata_v: 3,
+    });
+
+    expect(mockEncryptWithChatKey).toHaveBeenCalledWith(
+      "Generated summary from the completed response",
+      expect.any(Uint8Array),
+    );
+    expect(mockChatDB.updateChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chat_id: "chat-1",
+        encrypted_chat_summary:
+          "encrypted:Generated summary from the completed response",
+        encrypted_auto_speak_response: "encrypted:true",
+      }),
+    );
+    expect(mockSendPostProcessingMetadata).toHaveBeenCalledWith(
+      service,
+      "chat-1",
+      "",
+      [],
+      "encrypted:Generated summary from the completed response",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "encrypted-chat-key",
+    );
+  });
 });
 
 describe("handleEmbedUpdateImpl", () => {

--- a/frontend/packages/ui/src/services/__tests__/chatSyncServiceHandlersCoreSync.test.ts
+++ b/frontend/packages/ui/src/services/__tests__/chatSyncServiceHandlersCoreSync.test.ts
@@ -58,6 +58,9 @@ const mocks = vi.hoisted(() => ({
     markPhase1Empty: vi.fn(),
     setInspirations: vi.fn(),
   },
+  activeChatStore: {
+    get: vi.fn((): string | null => null),
+  },
 }));
 
 vi.mock("../db", () => ({ chatDB: mocks.chatDB }));
@@ -79,7 +82,7 @@ vi.mock("../../stores/notificationStore", () => ({
   notificationStore: { chatMessage: vi.fn(), error: vi.fn() },
 }));
 vi.mock("../../stores/activeChatStore", () => ({
-  activeChatStore: { get: vi.fn(() => null) },
+  activeChatStore: mocks.activeChatStore,
 }));
 vi.mock("../chatSyncMessageKeyGuard", () => ({
   filterPersistableSyncedMessages: vi.fn(async (messages) => messages),
@@ -97,6 +100,7 @@ afterEach(() => {
 describe("handleCacheStatusResponseImpl", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.activeChatStore.get.mockReturnValue(null);
     vi.stubGlobal(
       "CustomEvent",
       class TestCustomEvent {
@@ -186,6 +190,44 @@ describe("handlePhase1LastChatImpl", () => {
       "software",
       "code",
       true,
+    );
+  });
+
+  // contract-test: direct surface=gui.web assertions=chats.persistence.client-encrypted,chats.local-state.precedence,sync.startup.bounded-phases
+  it("notifies the active chat when Phase 1a stores authoritative header metadata", async () => {
+    const service = { dispatchEvent: vi.fn() } as unknown as ChatSynchronizationService;
+    mocks.activeChatStore.get.mockReturnValue("chat-1");
+
+    await handlePhase1LastChatImpl(service, {
+      chat_id: "chat-1",
+      chat_details: {
+        encrypted_title: "server-encrypted-title",
+        encrypted_icon: "server-encrypted-icon",
+        encrypted_category: "server-encrypted-category",
+        encrypted_chat_key: "same-key",
+        messages_v: 4,
+        title_v: 2,
+        metadata_v: 2,
+      },
+      messages: null,
+      recent_chat_metadata: [],
+      phase: "phase1",
+    });
+
+    expect(service.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "chatUpdated",
+        detail: expect.objectContaining({
+          chat_id: "chat-1",
+          type: "metadata_updated",
+          chat: expect.objectContaining({
+            chat_id: "chat-1",
+            encrypted_title: "server-encrypted-title",
+            encrypted_icon: "server-encrypted-icon",
+            encrypted_category: "server-encrypted-category",
+          }),
+        }),
+      }),
     );
   });
 

--- a/frontend/packages/ui/src/services/chatSyncServiceHandlersAI.ts
+++ b/frontend/packages/ui/src/services/chatSyncServiceHandlersAI.ts
@@ -2404,11 +2404,17 @@ export async function handlePostProcessingCompletedImpl(
       const latestChatForSummary = await chatDB.getChat(payload.chat_id);
       const latestMetadataV = Math.max(
         latestChatForSummary?.metadata_v ?? 0,
-        latestChatForSummary?.title_v ?? 0,
         chat.metadata_v ?? 0,
-        chat.title_v ?? 0,
       );
-      if (sourceMetadataV !== null && latestMetadataV > sourceMetadataV) {
+      const summaryWasAlreadyChanged = Boolean(
+        latestChatForSummary?.encrypted_chat_summary ??
+          chat.encrypted_chat_summary,
+      );
+      if (
+        sourceMetadataV !== null &&
+        latestMetadataV > sourceMetadataV &&
+        summaryWasAlreadyChanged
+      ) {
         console.info(
           `[ChatSyncService:AI] Skipping stale post-processing summary update for chat ${payload.chat_id} ` +
             `(source_metadata_v=${sourceMetadataV}, current_metadata_v=${latestMetadataV})`,

--- a/frontend/packages/ui/src/services/chatSyncServiceHandlersCoreSync.ts
+++ b/frontend/packages/ui/src/services/chatSyncServiceHandlersCoreSync.ts
@@ -542,6 +542,27 @@ export async function handlePhase1LastChatImpl(
     // Store in phasedSyncStateStore for immediate rendering
     phasedSyncState.setRecentChats(recentChatsDecrypted);
 
+    // Phase 1a may finish after a deep-linked chat has already rendered from a
+    // partial local shell. Reuse the normal metadata event for that one active
+    // chat so its header re-reads the authoritative record just stored in IDB.
+    // Do not broadcast updates for every recent chat: sidebar consumers already
+    // receive phasedSyncState, and doing so would create needless render churn.
+    const activeChatId = activeChatStore.get();
+    const activeSyncedChat = activeChatId
+      ? allPhase1Chats.find((chat) => chat.chat_id === activeChatId)
+      : undefined;
+    if (activeSyncedChat) {
+      serviceInstance.dispatchEvent(
+        new CustomEvent("chatUpdated", {
+          detail: {
+            chat_id: activeSyncedChat.chat_id,
+            type: "metadata_updated",
+            chat: activeSyncedChat,
+          },
+        }),
+      );
+    }
+
     // Populate resume card only when the last-opened chat survived validation.
     const lastChat = acceptedLastChatId
       ? recentChatsDecrypted.find(({ chat }) => chat.chat_id === acceptedLastChatId)
@@ -907,6 +928,8 @@ export function handleCacheStatusResponseImpl(
       serviceInstance.initialSyncAttempted_FOR_HANDLERS_ONLY,
   });
 
+  serviceInstance.cacheStatusServerChatCount_FOR_HANDLERS_ONLY = payload.chat_count;
+
   if (payload.is_primed && !serviceInstance.cachePrimed_FOR_HANDLERS_ONLY) {
     console.log(
       "[ChatSyncService:CoreSync] ✅ Cache is primed! Setting flag and attempting initial sync...",
@@ -931,6 +954,9 @@ export function handleCacheStatusResponseImpl(
     // Schedule a retry to poll for completion. The cache_primed push event should also
     // arrive when warming completes, but polling provides a reliable fallback in case
     // the push event is missed (e.g., brief WebSocket reconnection window).
+    if (payload.chat_count > 0) {
+      phasedSyncState.markSyncPending();
+    }
     console.warn(
       "[ChatSyncService:CoreSync] Cache not primed yet. Backend is re-warming. Scheduling status retry...",
     );


### PR DESCRIPTION
## Scope

Forward-only hotfix based on production main 8aa9fd4. Includes chat summary/header and cold-cache recovery, EMH2K parallel image tool-result grouping, regional bucket provisioning with preserved exclusions, and generated email locales. No new models, task/activity features, dependency updates, or S3 object backfill. Full release PR #512 stays blocked.

## Exact-candidate evidence

Commit: 424aa4705ac2d8594e3599b4ff7feedfd8804593.

- 29 focused frontend tests passed: https://github.com/glowingkitty/OpenMates/actions/runs/33916254886
- 25 focused backend tests passed: https://github.com/glowingkitty/OpenMates/actions/runs/33916256893
- Vercel preview and all container builds passed.
- PR container builds do not publish images.

## Remaining gates

The core-journey workflow rejects non-dev branches; journeys were skipped, not passed. No exact-candidate readiness attestation exists. Do not bypass the gate or substitute other-commit evidence. Production deployment requires renewed SSH access, image publication, managed update, and core chat/signup/card verification. The draft prerelease remains unpublished.