### PR TITLE
fix: restore production account deletion archive inventory

### DIFF
--- a/backend/core/api/app/services/storage_reference_service.py
+++ b/backend/core/api/app/services/storage_reference_service.py
@@ -362,17 +362,17 @@ async def persist_account_storage_tombstones(
         inventory.references.add(("profile_images_legacy", legacy_key))
 
     archive_collections = (
-        ("usage_monthly_chat_summaries", "usage_archives"),
-        ("usage_monthly_app_summaries", "usage_archives"),
-        ("usage_monthly_api_key_summaries", "usage_archives"),
-        ("user_task_archives", "task_archives"),
+        ("usage_monthly_chat_summaries", "usage_archives", "user_id_hash"),
+        ("usage_monthly_app_summaries", "usage_archives", "user_id_hash"),
+        ("usage_monthly_api_key_summaries", "usage_archives", "user_id_hash"),
+        ("user_task_archives", "task_archives", "hashed_user_id"),
     )
-    for collection, logical_bucket in archive_collections:
+    for collection, logical_bucket, owner_field in archive_collections:
         rows = await _get_items_bounded(
             directus_service=directus_service,
             collection=collection,
             fields="id,archive_s3_key",
-            item_filter={"hashed_user_id": {"_eq": user_id_hash}},
+            item_filter={owner_field: {"_eq": user_id_hash}},
         )
         excluded_ids[collection] = {
             str(row["id"]) for row in rows if row.get("id")

--- a/backend/tests/test_account_deletion_storage_lifecycle.py
+++ b/backend/tests/test_account_deletion_storage_lifecycle.py
@@ -22,12 +22,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 class FakeDirectus:
     def __init__(self) -> None:
         self.created: list[dict] = []
+        self.get_items_calls: list[tuple[str, dict[str, object]]] = []
         self.chats = [{"id": "chat-1", "storage_state": "hot", "archive_version": 1}]
 
     async def get_user_fields_direct(self, _user_id: str, _fields: list[str]) -> dict:
         return {"id": "user-1", "profile_image_s3_key": "profiles/user-1.enc"}
 
-    async def get_items(self, collection: str, **_kwargs: object) -> list[dict]:
+    async def get_items(self, collection: str, **kwargs: object) -> list[dict]:
+        self.get_items_calls.append((collection, kwargs))
         if collection == "chats":
             return self.chats
         rows = {
@@ -124,6 +126,30 @@ async def test_account_inventory_persists_every_non_regulated_object_before_owne
         ("cold_archives", "cold/chat-1/part-1.json.gz"),
     }
     assert all("user_id" not in row for row in directus.created)
+    archive_filters = {
+        collection: kwargs["params"]["filter"]
+        for collection, kwargs in directus.get_items_calls
+        if collection
+        in {
+            "usage_monthly_chat_summaries",
+            "usage_monthly_app_summaries",
+            "usage_monthly_api_key_summaries",
+            "user_task_archives",
+        }
+        and "filter" in kwargs["params"]
+    }
+    assert archive_filters == {
+        "usage_monthly_chat_summaries": {
+            "user_id_hash": {"_eq": "hashed-user-1"}
+        },
+        "usage_monthly_app_summaries": {
+            "user_id_hash": {"_eq": "hashed-user-1"}
+        },
+        "usage_monthly_api_key_summaries": {
+            "user_id_hash": {"_eq": "hashed-user-1"}
+        },
+        "user_task_archives": {"hashed_user_id": {"_eq": "hashed-user-1"}},
+    }
 
 
 # contract-test: direct surface=rest_api assertions=storage.deletion.global-authoritative


### PR DESCRIPTION
## Summary

Restores production account deletion after storage inventory was blocked by a Directus field mismatch. Monthly usage summary archives now use their deployed `user_id_hash` owner field, while task archives continue using `hashed_user_id`.

## Bug Fixes

- Query each archive collection with its schema-defined owner field.
- Add an exact regression assertion for all four archive inventory queries.

## Verification

- `python3 -m pytest backend/tests/test_account_deletion_storage_lifecycle.py backend/tests/test_storage_reference_service.py -q` — 7 passed
- Scoped Python lint — passed
- Hotfix files exactly match dev commit `7338b5a1755a646088b7e3506bb80177dddbb4d6`

No schema migration or user-data mutation is included.